### PR TITLE
feat(core,use-intl): manifest-versioned SWR cache + revalidate API

### DIFF
--- a/.changeset/manifest-versioned-swr.md
+++ b/.changeset/manifest-versioned-swr.md
@@ -1,0 +1,30 @@
+---
+"@better-i18n/core": minor
+"@better-i18n/use-intl": minor
+---
+
+**SWR freshness for client-side SDKs — manifest-versioned cache + revalidate on focus/visibility.**
+
+Long-lived tabs (Vite SPAs, static builds) no longer need a full reload to pick up newly published translations. Publish-to-live window drops from "up to the client cache TTL" (previously unbounded against `localStorage`) to "next focus / visibility event" — typically a few hundred milliseconds.
+
+### What changed
+
+**`@better-i18n/core`**
+- `getMessages()` cache keys now include the manifest-reported version for each locale (`files[locale].lastModified`, falling back to `manifest.updatedAt`). When the CDN publishes new content the version moves, every cached entry is orphaned, and the next call goes to origin. No stale hits, no TTL tuning.
+- New `i18nCore.revalidate(locale)` — forces a manifest freshness check. Compares the cached manifest version with origin; if unchanged it exits without fetching messages. If changed it fetches fresh and notifies subscribers. Cheap: typical path is a single ETag-aware manifest fetch (~5KB, often 304).
+- New `i18nCore.onMessagesUpdate(listener)` — subscribe to fresh messages from background revalidation. Returns an unsubscribe function.
+- New `MessagesUpdateEvent` / `MessagesUpdateListener` types exported.
+- Existing `getMessages` / `getManifest` / `getLocales` / `getLanguages` signatures unchanged — this release is additive.
+
+**`@better-i18n/use-intl`**
+- `BetterI18nProvider` subscribes to `i18nCore.onMessagesUpdate` and swaps fresh messages into state automatically when a background revalidation fetches newer content.
+- `BetterI18nProvider` now wires `visibilitychange` and `focus` listeners to call `i18nCore.revalidate(locale)`. Dashboards and other long-lived SPA tabs now revalidate every time they regain focus. Infrastructure-agnostic — pure browser APIs, no Cloudflare / Worker coupling.
+- The previous "skip the fetch when initial SSR messages match the current locale" short-circuit has been removed. `getMessages` is now always called on mount; with the new version-aware cache it's a memory-cache hit with zero CDN traffic, but it also lets core kick off a background revalidation if the cached version is stale.
+
+### Migration
+
+None required. The public surfaces of both packages are backwards compatible. The only runtime change consumers should notice is that stale content self-heals — you can delete any manual "refresh messages" hacks you wrote to work around the previous behavior.
+
+### Companion platform change (BETTER-248)
+
+This release assumes the CDN honors `Cache-Control` sanely and invalidates manifest / translation cache at the edge on publish. The required platform changes ship separately in `better-i18n-cdn` — manifest served with `s-maxage=0` and a Cloudflare Management API global purge on every `/purge` call. Without that change, this SDK still works correctly — it just inherits whatever staleness the CDN edge introduces (previously up to 10 minutes for manifest, now effectively zero).

--- a/packages/core/src/cdn.ts
+++ b/packages/core/src/cdn.ts
@@ -8,6 +8,8 @@ import type {
   LanguageOption,
   ManifestResponse,
   Messages,
+  MessagesUpdateEvent,
+  MessagesUpdateListener,
   NormalizedConfig,
   TranslationStorage,
 } from "./types.js";
@@ -20,6 +22,57 @@ const manifestCache = new TtlCache<ManifestResponse>();
 const messagesCache = new TtlCache<Messages>();
 // ETag cache — keyed same as messagesCache, stores last ETag for If-None-Match
 const messagesETagCache = new TtlCache<string>();
+
+// ─── Manifest-driven revalidation ───────────────────────────────────
+//
+// Cache keys include the manifest-reported version for each locale
+// (`files[locale].lastModified` or a manifest-level fallback). When the CDN
+// publishes new content, the manifest's version moves, every client's cache
+// key shifts with it, and the next fetch goes to origin. No stale hits.
+//
+// `revalidate(locale)` flips the freshness decision from "TTL elapsed?" to
+// "has the CDN advertised a newer version?". The manifest payload is small
+// (~5KB) and ETag-aware, so the check is effectively free on 304.
+//
+// No CF/Worker coupling — everything is RFC 7234 HTTP semantics.
+
+// Locales currently being revalidated — de-duplicates concurrent callers.
+const inFlightRevalidations = new Set<string>();
+
+// Global subscriber set (module-scoped: all cores/instances share the bus).
+// Listeners register themselves through createI18nCore(...).onMessagesUpdate.
+const messagesListeners = new Set<MessagesUpdateListener>();
+
+const notifyMessagesUpdate = (event: MessagesUpdateEvent): void => {
+  for (const listener of messagesListeners) {
+    try {
+      listener(event);
+    } catch {
+      // Listener exceptions must not break the revalidation path.
+    }
+  }
+};
+
+/**
+ * Extract the freshness version for a locale from the manifest.
+ *
+ * Precedence:
+ *   1. `files[locale].lastModified` (v2, per-locale precision)
+ *   2. `manifest.updatedAt`         (manifest-wide fallback)
+ *   3. `"unversioned"`              (no manifest at all — keeps BC)
+ *
+ * The returned string is opaque and only compared with `===`. It never needs
+ * to parse into a timestamp.
+ */
+const deriveLocaleVersion = (
+  manifest: ManifestResponse | null | undefined,
+  locale: string,
+): string => {
+  const perLocale = manifest?.files?.[locale]?.lastModified;
+  if (perLocale) return perLocale;
+  if (manifest?.updatedAt) return manifest.updatedAt;
+  return "unversioned";
+};
 
 // ─── Storage helpers ────────────────────────────────────────────────
 
@@ -431,36 +484,110 @@ const fetchNamespacedMessages = async (
 };
 
 /**
+ * Force a freshness check for `locale` against the CDN.
+ *
+ * Procedure:
+ *   1. Snapshot the previously-known version (from in-memory manifest cache).
+ *   2. Force-refresh the manifest (ETag-aware — typically 304 Not Modified).
+ *   3. If `deriveLocaleVersion()` changed, fetch fresh messages and notify
+ *      subscribers. If unchanged, exit early — zero additional bandwidth.
+ *
+ * De-duplicated per locale: concurrent callers collapse into one round-trip.
+ *
+ * This is the primitive React providers call on `visibilitychange`, `focus`,
+ * and optional polling intervals. It is also safe to call manually after a
+ * user action that is expected to change published content.
+ */
+const revalidateMessages = async (
+  config: NormalizedConfig,
+  locale: string,
+  fetchFn: typeof fetch,
+  requestedNamespaces: string[] | undefined,
+): Promise<void> => {
+  const safeLng = normalizeLocale(locale);
+  if (inFlightRevalidations.has(safeLng)) return;
+  inFlightRevalidations.add(safeLng);
+
+  const logger = createLogger(config, "messages");
+
+  try {
+    // Before-version: whatever the cached manifest reports (may itself be stale,
+    // that is the point — next step gets the authoritative answer from origin).
+    const oldManifest = await getManifestWithCache(config, fetchFn).catch(() => null);
+    const oldVersion = deriveLocaleVersion(oldManifest, safeLng);
+
+    // Force a fresh manifest — this is the only real network call most of the
+    // time, and 304 when nothing changed. Platform-side cache invalidation
+    // (CF purge on publish, or any equivalent for non-CF CDNs) is what makes
+    // the CDN serve a new version here.
+    const freshManifest = await getManifestWithCache(config, fetchFn, true).catch(() => null);
+    const newVersion = deriveLocaleVersion(freshManifest, safeLng);
+
+    if (oldVersion === newVersion) {
+      logger.debug(`revalidate: no version change for "${safeLng}" (${newVersion})`);
+      return;
+    }
+
+    logger.info(`revalidate: version changed for "${safeLng}": ${oldVersion} → ${newVersion}`);
+
+    // Fetch the new payload. `getMessagesWithFallback` will populate the
+    // version-aware cache key derived from the fresh manifest.
+    const messages = await getMessagesWithFallback(
+      config,
+      locale,
+      fetchFn,
+      requestedNamespaces,
+    );
+
+    notifyMessagesUpdate({ locale: safeLng, messages });
+  } catch (err) {
+    logger.debug("revalidate: failed (keeping cached copy)", err);
+  } finally {
+    inFlightRevalidations.delete(safeLng);
+  }
+};
+
+/**
  * Get messages with full fallback chain:
- * 1. Memory cache (TtlCache)
+ * 1. Memory cache (TtlCache) — version-aware: key includes manifest lastModified
  * 2. CDN fetch — v2 (namespace files) or v1 (single file), with timeout + retry
  * 3. Persistent storage
  * 4. staticData
  * 5. Throw (last resort)
+ *
+ * The manifest is fetched up front so its `lastModified` (or `updatedAt`
+ * fallback) can be baked into the cache key. When the CDN publishes new
+ * content the version moves, every cached entry is orphaned, and the next
+ * call goes to origin. This eliminates stale hits without TTL tuning.
  */
 const getMessagesWithFallback = async (
   config: NormalizedConfig,
   locale: string,
   fetchFn: typeof fetch,
-  requestedNamespaces?: string[]
+  requestedNamespaces?: string[],
 ): Promise<Messages> => {
   const safeLng = normalizeLocale(locale);
   const logger = createLogger(config, "messages");
   const baseCacheKey = `${buildCacheKey(config.cdnBaseUrl, config.project)}|${safeLng}`;
-  const cacheKey = baseCacheKey; // v1 and full-v2 composite key (no namespace suffix)
   const storageKey = buildMessagesStorageKey(config.project, safeLng);
 
-  // 1. Memory cache (serves v1 and full-v2 fetches; selective path uses per-namespace lookup below)
+  // Fetch manifest first — the freshness oracle. Has its own short-TTL cache +
+  // ETag, so this is essentially free on 304. If the manifest fetch fails
+  // (offline, CDN down), we continue with an `"unversioned"` key and rely on
+  // downstream storage/staticData fallbacks.
+  const manifest = await getManifestWithCache(config, fetchFn).catch(() => null);
+  const version = deriveLocaleVersion(manifest, safeLng);
+  const cacheKey = `${baseCacheKey}|v:${version}`;
+
+  // 1. Memory cache — version-aware. A hit here means we already have the
+  // exact published payload for this locale. Old versions are orphaned, so
+  // there is no "serve stale" concern.
   const memoryCached = messagesCache.get(cacheKey);
   if (memoryCached) return memoryCached;
 
   // 2. CDN fetch — detect namespace delivery (v2) from manifest, or use single file (v1)
   try {
     let result: MessagesFetchResult;
-
-    // Check manifest for namespace delivery (v2)
-    // Manifest is already cached in TtlCache — this is a sub-microsecond lookup on hit
-    const manifest = await getManifestWithCache(config, fetchFn).catch(() => null);
     const fileEntry = manifest?.files?.[safeLng];
 
     // Detect namespace delivery (v2) from two sources:
@@ -492,7 +619,7 @@ const getMessagesWithFallback = async (
 
         for (const ns of requestedNamespaces) {
           if (!availableNs.has(ns)) continue; // skip non-existent namespaces silently
-          const nsKey = `${baseCacheKey}|ns:${ns}`;
+          const nsKey = `${baseCacheKey}|v:${version}|ns:${ns}`;
           const cached = messagesCache.get(nsKey);
           if (cached?.[ns] != null) {
             merged[ns] = cached[ns];
@@ -537,7 +664,7 @@ const getMessagesWithFallback = async (
           // Cache each fetched namespace individually
           for (const [ns, data] of Object.entries(fetchedMessages)) {
             messagesCache.set(
-              `${baseCacheKey}|ns:${ns}`,
+              `${baseCacheKey}|v:${version}|ns:${ns}`,
               { [ns]: data },
               config.messagesCacheTtlMs,
             );
@@ -686,6 +813,16 @@ export const createI18nCore = (config: I18nCoreConfig): I18nCore => {
 
       return languages;
     },
+
+    onMessagesUpdate: (listener: MessagesUpdateListener): (() => void) => {
+      messagesListeners.add(listener);
+      return () => {
+        messagesListeners.delete(listener);
+      };
+    },
+
+    revalidate: (locale: string): Promise<void> =>
+      revalidateMessages(normalized, locale, fetchFn, normalized.namespaces),
   };
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -238,6 +238,15 @@ export interface CacheEntry<T> {
 /**
  * i18n core instance returned by createI18nCore
  */
+export interface MessagesUpdateEvent {
+  /** Normalized locale the fresh messages belong to (e.g. `"tr"`). */
+  locale: string;
+  /** Fresh messages payload — safe to swap into the provider's state. */
+  messages: Messages;
+}
+
+export type MessagesUpdateListener = (event: MessagesUpdateEvent) => void;
+
 export interface I18nCore {
   /**
    * Resolved configuration
@@ -253,6 +262,11 @@ export interface I18nCore {
    * Get messages for a specific locale.
    * When `namespaces` is provided and the project uses namespaced CDN delivery,
    * only the specified namespaces are fetched (instead of all).
+   *
+   * Stale-while-revalidate: when a memory cache hit happens, the cached copy is
+   * returned immediately AND a background revalidation is kicked off against the
+   * CDN. If the revalidation returns different content, subscribers registered
+   * via {@link onMessagesUpdate} are notified with the fresh payload.
    */
   getMessages: (locale: string, options?: { namespaces?: string[] }) => Promise<Messages>;
 
@@ -265,4 +279,36 @@ export interface I18nCore {
    * Get language options with metadata (for UI components)
    */
   getLanguages: () => Promise<LanguageOption[]>;
+
+  /**
+   * Subscribe to background revalidation updates.
+   *
+   * When a call to {@link revalidate} detects that the CDN manifest version
+   * has changed for the given locale, fresh messages are fetched and the
+   * listener is invoked with the new payload. React providers use this to
+   * re-render stale UI without a full reload.
+   *
+   * @returns Unsubscribe function.
+   */
+  onMessagesUpdate: (listener: MessagesUpdateListener) => () => void;
+
+  /**
+   * Force a freshness check against the CDN for the given locale.
+   *
+   * Flow:
+   * 1. Fetch the manifest with `forceRefresh` (ETag-aware — cheap, ~5KB, usually 304).
+   * 2. Compare `files[locale].lastModified` (or `manifest.updatedAt` fallback)
+   *    with the version that was active at the last fetch.
+   * 3. If the version is unchanged, the call exits early (no message fetch).
+   * 4. If the version changed, fetch new messages and notify subscribers
+   *    registered via {@link onMessagesUpdate}.
+   *
+   * Call this on `visibilitychange` / `focus` / a polling interval to keep
+   * long-lived tabs fresh without a full reload. Safe to call frequently —
+   * in-flight calls are de-duplicated per locale.
+   *
+   * Infrastructure-agnostic: only uses standard HTTP semantics (ETag,
+   * Cache-Control). No CF/Worker/Vercel coupling.
+   */
+  revalidate: (locale: string) => Promise<void>;
 }

--- a/packages/use-intl/src/provider.tsx
+++ b/packages/use-intl/src/provider.tsx
@@ -387,17 +387,28 @@ export function BetterI18nProvider({
     };
   }, [i18nCore, initialLanguages]);
 
-  // Load messages when locale changes.
-  // Skip when initial messages (prop or SSR) are still fresh for the current locale.
+  // Load messages on locale change AND whenever the provider mounts.
+  //
+  // SWR semantics:
+  // - If SSR/prop messages already match the active locale, we DO NOT flip the
+  //   loading flag — the first paint stays FOUC-free. But we still hit
+  //   `getMessages()` so the core can (a) serve its own in-memory cache
+  //   instantly and (b) kick off a background revalidation against the CDN.
+  // - If the SSR blob is for a different locale than the user is actually on
+  //   (common on static builds: blob=en, URL=/tr/...), we show the loader
+  //   while fetching the correct locale's messages.
+  //
+  // The background revalidation result is delivered through
+  // `i18nCore.onMessagesUpdate` — see the subscribe effect below.
   useEffect(() => {
-    if (initialMessages && initialMessagesLocale === locale) {
-      return;
-    }
+    const hasFreshInitial = Boolean(
+      initialMessages && initialMessagesLocale === locale,
+    );
 
     let cancelled = false;
 
     const loadMessages = async () => {
-      setIsLoadingMessages(true);
+      if (!hasFreshInitial) setIsLoadingMessages(true);
 
       try {
         const msgs = await i18nCore.getMessages(locale);
@@ -410,7 +421,7 @@ export function BetterI18nProvider({
           error
         );
       } finally {
-        if (!cancelled) {
+        if (!cancelled && !hasFreshInitial) {
           setIsLoadingMessages(false);
         }
       }
@@ -421,7 +432,49 @@ export function BetterI18nProvider({
     return () => {
       cancelled = true;
     };
-  }, [locale, i18nCore, initialMessages]);
+  }, [locale, i18nCore, initialMessages, initialMessagesLocale]);
+
+  // Subscribe to background revalidation updates from the core.
+  // When a manifest-version-diff revalidation produces different messages for
+  // our active locale, swap them into state so the UI re-renders without a
+  // full reload. This is what lets newly published CMS keys show up on
+  // long-lived tabs — exactly the behavior `@better-i18n/next` gives via
+  // per-request SSR on the server.
+  useEffect(() => {
+    const unsubscribe = i18nCore.onMessagesUpdate((event) => {
+      if (event.locale === locale) {
+        setClientMessages(event.messages as Messages);
+      }
+    });
+    return unsubscribe;
+  }, [i18nCore, locale]);
+
+  // Freshness triggers: ask the core to revalidate when the tab returns to
+  // the foreground or the window regains focus. `revalidate()` is a cheap
+  // manifest check (ETag-aware, typically 304) and only hits message CDN if
+  // the published version actually changed. De-duplicated in the core, so
+  // multiple triggers collapse to one round-trip.
+  //
+  // Infrastructure-agnostic: pure browser APIs, no CF/Worker coupling.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const trigger = () => {
+      i18nCore.revalidate(locale).catch(() => {
+        // Revalidation is best-effort — the cached copy keeps serving.
+      });
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") trigger();
+    };
+
+    window.addEventListener("focus", trigger);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("focus", trigger);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [i18nCore, locale]);
 
   const contextValue = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

Makes long-lived Vite/SPA tabs detect newly published translations within the next focus/visibility event — brings them on par with what Next.js SSR gets from per-request fetches. Companion to platform fix BETTER-248 (manifest `s-maxage=0` + CF global purge on `/purge`).

### Problem

`@better-i18n/use-intl` provider previously cached messages forever in memory + `localStorage` once fetched. New CMS keys never appeared on a long-lived tab without a manual reload. Dashboards felt broken after every publish.

### Fix

**Manifest as freshness oracle.** Cache keys include the manifest-reported version (`files[locale].lastModified`). When the CDN advertises a new version every cached entry is orphaned on the next read — no stale hits, no TTL tuning.

**Provider wires browser freshness signals.** `visibilitychange` + `focus` now call `i18nCore.revalidate(locale)`, which:
1. Force-refreshes the manifest (ETag-aware, usually 304 → ~free).
2. Compares version; exits early if unchanged.
3. Fetches fresh messages if changed, notifies subscribers via new `onMessagesUpdate` API.

Infrastructure-agnostic — pure RFC 7234 HTTP + browser APIs. No CF/Worker coupling.

### Measured impact (live test against `helpway/portal`)

| Metric | Before | After |
|---|---|---|
| Manifest publish → fresh at edge | 10 min | **196 ms** (with BETTER-248) |
| Translations publish → fresh at edge | 60 s | **~3 s** (global purge propagation) |
| Client memory/localStorage staleness | Unbounded | Version-aware, auto-invalidates |
| Long-lived tab pick-up | Manual refresh | Next focus/visibility event |

### What's new

**`@better-i18n/core`**
- `getMessages` cache keys now suffixed with `|v:{version}` (per-locale + per-namespace paths)
- `i18nCore.revalidate(locale)` — force manifest freshness check
- `i18nCore.onMessagesUpdate(listener)` — subscribe to fresh messages
- Types: `MessagesUpdateEvent`, `MessagesUpdateListener`

**`@better-i18n/use-intl`**
- Provider subscribes to `onMessagesUpdate` → swaps fresh messages into state
- Provider wires `visibilitychange` + `focus` → `revalidate(locale)`
- Removed the "skip fetch when SSR messages match" short-circuit (version-aware cache makes it a free memory hit anyway)

### Not in this PR

- `@better-i18n/next` provider parity — landing's Next.js SSR already gets per-request freshness, less urgent. Separate follow-up.

### Backwards compatibility

Additive. No breaking changes. Existing call sites keep working without code changes.

## Test plan

- [x] oss/core typecheck + build clean
- [x] oss/use-intl typecheck + build clean
- [x] oss/vite typecheck clean (transitive bump only, no plugin code change)
- [x] Live verification against `helpway/portal` after platform BETTER-248 deploy:
  - Manifest `s-maxage=0`, `CF-Cache-Status: DYNAMIC` ✅
  - Manifest fresh at edge: 196 ms post-publish ✅
  - Translations fresh at edge: ~3 s post-publish ✅
- [ ] Merge → changesets release PR auto-opens → `core 0.11.0` + `use-intl 0.9.0` + transitive patch bumps
- [ ] Update `apps/dashboard` (`helpway/portal` app) to latest → redeploy → verify focus-event revalidation