### PR TITLE
feat(mcp-content): block catalog MCP tools

### DIFF
--- a/.changeset/blocks-platform-mcp-tools.md
+++ b/.changeset/blocks-platform-mcp-tools.md
@@ -1,0 +1,22 @@
+---
+"@better-i18n/mcp-content": minor
+---
+
+Add Block Catalog MCP tools (BETTER-246 / BETTER-247).
+
+Six new tools for managing the per-project block catalog — code-first renderable
+primitives (hero, feature grid, cover, FAQ, CTA) registered by the customer's SDK
+and used by AI agents to compose content entries:
+
+- `registerBlock` — upsert one block by (project, slug) with JSON Schema + metadata
+- `bulkRegisterBlocks` — register up to 50 blocks atomically in one transaction
+- `listBlocks` — browse the catalog with optional category/search filters
+- `getBlock` — fetch a single block's full detail including paramsSchema
+- `validateBlockParams` — dry-run validate block params against the stored schema
+- `deleteBlock` — remove a block from the catalog (policies: strict/warn/orphan)
+
+Only JSON Schema + metadata are stored — no customer render code enters Better.
+Static PNG previews and optional iframe live previews are customer-hosted.
+
+Paired with platform changes to `mcpContent` tRPC router and the new
+`block_catalog` Postgres table.

--- a/packages/mcp-content/src/server.ts
+++ b/packages/mcp-content/src/server.ts
@@ -44,6 +44,14 @@ import { updateField } from "./tools/updateField.js";
 import { removeField } from "./tools/removeField.js";
 import { reorderFields } from "./tools/reorderFields.js";
 
+// Block catalog tools (BETTER-246 / BETTER-247)
+import { registerBlock } from "./tools/registerBlock.js";
+import { bulkRegisterBlocks } from "./tools/bulkRegisterBlocks.js";
+import { listBlocks } from "./tools/listBlocks.js";
+import { getBlock } from "./tools/getBlock.js";
+import { validateBlockParams } from "./tools/validateBlockParams.js";
+import { deleteBlock } from "./tools/deleteBlock.js";
+
 export interface ServerConfig {
   apiUrl: string;
   apiKey: string;
@@ -186,6 +194,13 @@ All string inputs are UTF-8. Send non-ASCII characters in every language (diacri
     updateField,
     removeField,
     reorderFields,
+    // Block catalog
+    registerBlock,
+    bulkRegisterBlocks,
+    listBlocks,
+    getBlock,
+    validateBlockParams,
+    deleteBlock,
   };
 
   // List available tools
@@ -211,10 +226,18 @@ All string inputs are UTF-8. Send non-ASCII characters in every language (diacri
       annotate(addField.definition, write),
       annotate(updateField.definition, write),
       annotate(reorderFields.definition, write),
+      // Block catalog (read)
+      annotate(listBlocks.definition, readOnly),
+      annotate(getBlock.definition, readOnly),
+      annotate(validateBlockParams.definition, readOnly),
+      // Block catalog (write)
+      annotate(registerBlock.definition, write),
+      annotate(bulkRegisterBlocks.definition, write),
       // Destructive
       annotate(deleteContentEntry.definition, destructive),
       annotate(deleteContentModel.definition, destructive),
       annotate(removeField.definition, destructive),
+      annotate(deleteBlock.definition, destructive),
     ],
   }));
 

--- a/packages/mcp-content/src/tools/bulkRegisterBlocks.ts
+++ b/packages/mcp-content/src/tools/bulkRegisterBlocks.ts
@@ -1,0 +1,82 @@
+/**
+ * bulkRegisterBlocks MCP Tool
+ *
+ * Atomically register up to 50 blocks in one call. Ideal for syncing an entire
+ * block registry from code.
+ */
+
+import { z } from "zod";
+import {
+  executeTool,
+  projectInputProperty,
+  projectSchema,
+  success,
+} from "../base-tool.js";
+import type { Tool } from "../types/index.js";
+
+const blockDefinition = z.object({
+  slug: z
+    .string()
+    .min(2)
+    .max(64)
+    .regex(/^[a-z][a-z0-9-]*$/),
+  displayName: z.string().min(1).max(120),
+  category: z.string().max(64).optional(),
+  description: z.string().max(500).optional(),
+  jsonSchema: z.record(z.string(), z.unknown()),
+  previewUrl: z.string().url().optional(),
+  previewOrigin: z.string().url().optional(),
+  sourceCommit: z.string().max(64).optional(),
+});
+
+const inputSchema = projectSchema.extend({
+  blocks: z.array(blockDefinition).min(1).max(50),
+});
+
+export const bulkRegisterBlocks: Tool = {
+  definition: {
+    name: "bulkRegisterBlocks",
+    description: `Register up to 50 blocks atomically in a single transaction.
+
+Prefer this over looping registerBlock when syncing an entire registry from code. All-or-nothing: if any block's schema is invalid, the whole batch is rejected.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectInputProperty,
+        blocks: {
+          type: "array",
+          description: "Array of block definitions (1-50)",
+          items: {
+            type: "object",
+            properties: {
+              slug: { type: "string" },
+              displayName: { type: "string" },
+              category: { type: "string" },
+              description: { type: "string" },
+              jsonSchema: { type: "object" },
+              previewUrl: { type: "string" },
+              previewOrigin: { type: "string" },
+              sourceCommit: { type: "string" },
+            },
+            required: ["slug", "displayName", "jsonSchema"],
+          },
+        },
+      },
+      required: ["project", "blocks"],
+    },
+  },
+
+  execute: (client, args) =>
+    executeTool(args, inputSchema, async (input, { workspaceId, projectSlug }) => {
+      const result = await client.mcpContent.bulkRegisterBlocks.mutate({
+        orgSlug: workspaceId,
+        projectSlug,
+        blocks: input.blocks,
+      });
+
+      return success({
+        registered: result.registered,
+        blocks: result.blocks,
+      });
+    }),
+};

--- a/packages/mcp-content/src/tools/deleteBlock.ts
+++ b/packages/mcp-content/src/tools/deleteBlock.ts
@@ -1,0 +1,67 @@
+/**
+ * deleteBlock MCP Tool
+ *
+ * Remove a block from the project's catalog. DESTRUCTIVE — existing content
+ * entries referencing this block may stop rendering depending on policy.
+ */
+
+import { z } from "zod";
+import {
+  executeTool,
+  projectInputProperty,
+  projectSchema,
+  success,
+} from "../base-tool.js";
+import type { Tool } from "../types/index.js";
+
+const inputSchema = projectSchema.extend({
+  slug: z
+    .string()
+    .min(2)
+    .max(64)
+    .regex(/^[a-z][a-z0-9-]*$/),
+  policy: z.enum(["strict", "warn", "orphan"]).default("strict"),
+});
+
+export const deleteBlock: Tool = {
+  definition: {
+    name: "deleteBlock",
+    description: `DESTRUCTIVE: Remove a block from the project's catalog.
+
+Policy controls what happens to existing content entries referencing this block:
+- strict (default): fail if any entry uses it (v1: not yet enforced — treats all policies as unconditional delete)
+- warn: delete and mark affected entries with a warning flag
+- orphan: delete; entries keep raw JSON but render nothing for this block type
+
+Consider deleting related entries first (deleteContentEntry) or reassigning them to a different block type.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectInputProperty,
+        slug: {
+          type: "string",
+          description: "Block slug to delete",
+        },
+        policy: {
+          type: "string",
+          enum: ["strict", "warn", "orphan"],
+          description:
+            "Deletion policy: strict (default), warn, or orphan",
+        },
+      },
+      required: ["project", "slug"],
+    },
+  },
+
+  execute: (client, args) =>
+    executeTool(args, inputSchema, async (input, { workspaceId, projectSlug }) => {
+      const result = await client.mcpContent.deleteBlock.mutate({
+        orgSlug: workspaceId,
+        projectSlug,
+        slug: input.slug,
+        policy: input.policy ?? "strict",
+      });
+
+      return success({ deleted: result.deleted });
+    }),
+};

--- a/packages/mcp-content/src/tools/getBlock.ts
+++ b/packages/mcp-content/src/tools/getBlock.ts
@@ -1,0 +1,55 @@
+/**
+ * getBlock MCP Tool
+ *
+ * Fetch a single block's full detail including its params JSON Schema.
+ */
+
+import { z } from "zod";
+import {
+  executeTool,
+  projectInputProperty,
+  projectSchema,
+  success,
+} from "../base-tool.js";
+import type { Tool } from "../types/index.js";
+
+const inputSchema = projectSchema.extend({
+  slug: z
+    .string()
+    .min(2)
+    .max(64)
+    .regex(/^[a-z][a-z0-9-]*$/),
+});
+
+export const getBlock: Tool = {
+  definition: {
+    name: "getBlock",
+    description: `Fetch a single block's full detail by slug.
+
+Returns: displayName, category, description, paramsSchema (JSON Schema for params), previewUrl, previewOrigin, sourceCommit, registeredAt, updatedAt.
+
+Use before composing block params — the paramsSchema tells you exactly which fields are required and their types/enums.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectInputProperty,
+        slug: {
+          type: "string",
+          description: "Block slug (e.g. 'cover-gradient')",
+        },
+      },
+      required: ["project", "slug"],
+    },
+  },
+
+  execute: (client, args) =>
+    executeTool(args, inputSchema, async (input, { workspaceId, projectSlug }) => {
+      const result = await client.mcpContent.getBlock.query({
+        orgSlug: workspaceId,
+        projectSlug,
+        slug: input.slug,
+      });
+
+      return success(result);
+    }),
+};

--- a/packages/mcp-content/src/tools/listBlocks.ts
+++ b/packages/mcp-content/src/tools/listBlocks.ts
@@ -1,0 +1,60 @@
+/**
+ * listBlocks MCP Tool
+ *
+ * Browse the registered block catalog for a project with optional filters.
+ */
+
+import { z } from "zod";
+import {
+  executeTool,
+  projectInputProperty,
+  projectSchema,
+  success,
+} from "../base-tool.js";
+import type { Tool } from "../types/index.js";
+
+const inputSchema = projectSchema.extend({
+  category: z.string().optional(),
+  search: z.string().optional(),
+});
+
+export const listBlocks: Tool = {
+  definition: {
+    name: "listBlocks",
+    description: `List all registered blocks for a project.
+
+Returns the catalog: slug, displayName, category, description, paramsSchema (JSON Schema for CMS forms + params validation), previewUrl, previewOrigin.
+
+Use this before composing block instances — the returned slugs are the only valid types for block params. Filters:
+- category: exact match (e.g. 'cover', 'marketing')
+- search: case-insensitive substring in slug/displayName/description`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectInputProperty,
+        category: {
+          type: "string",
+          description: "Filter by category (exact match)",
+        },
+        search: {
+          type: "string",
+          description:
+            "Case-insensitive substring match on slug, displayName, or description",
+        },
+      },
+      required: ["project"],
+    },
+  },
+
+  execute: (client, args) =>
+    executeTool(args, inputSchema, async (input, { workspaceId, projectSlug }) => {
+      const result = await client.mcpContent.listBlocks.query({
+        orgSlug: workspaceId,
+        projectSlug,
+        category: input.category,
+        search: input.search,
+      });
+
+      return success({ blocks: result.blocks });
+    }),
+};

--- a/packages/mcp-content/src/tools/registerBlock.ts
+++ b/packages/mcp-content/src/tools/registerBlock.ts
@@ -1,0 +1,109 @@
+/**
+ * registerBlock MCP Tool
+ *
+ * Upsert a single block in the project's block catalog by (project, slug).
+ * Called when a new `defineBlock()` is added in the customer's SDK client.
+ */
+
+import { z } from "zod";
+import {
+  executeTool,
+  projectInputProperty,
+  projectSchema,
+  success,
+} from "../base-tool.js";
+import type { Tool } from "../types/index.js";
+
+const inputSchema = projectSchema.extend({
+  slug: z
+    .string()
+    .min(2)
+    .max(64)
+    .regex(/^[a-z][a-z0-9-]*$/),
+  displayName: z.string().min(1).max(120),
+  category: z.string().max(64).optional(),
+  description: z.string().max(500).optional(),
+  jsonSchema: z.record(z.string(), z.unknown()),
+  previewUrl: z.string().url().optional(),
+  previewOrigin: z.string().url().optional(),
+  sourceCommit: z.string().max(64).optional(),
+});
+
+export const registerBlock: Tool = {
+  definition: {
+    name: "registerBlock",
+    description: `Upsert a single block in the project's block catalog by (project, slug).
+
+Blocks are code-first renderable primitives (hero, feature grid, cover, FAQ, CTA) defined by the customer's SDK client via 'defineBlock()'. This call stores the JSON Schema + metadata used by the CMS and by AI agents to compose entries.
+
+ONLY stores schema + metadata — no render code ever enters Better's infrastructure.
+
+On conflict: updates displayName, category, description, jsonSchema, preview fields, sourceCommit.
+
+Typical workflow:
+1. Developer writes 'defineBlock({ slug, params: z.object({...}), render })' in app code
+2. Run z.toJSONSchema() on params to extract JSON Schema
+3. Call registerBlock with the schema + metadata
+
+To register many blocks atomically, use bulkRegisterBlocks instead.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectInputProperty,
+        slug: {
+          type: "string",
+          description: "Block slug (kebab-case, unique per project). Example: 'cover-gradient'",
+        },
+        displayName: {
+          type: "string",
+          description: "Human-readable name shown in CMS picker",
+        },
+        category: {
+          type: "string",
+          description: "Grouping label for picker (e.g. 'cover', 'marketing')",
+        },
+        description: {
+          type: "string",
+          description: "Help text shown to editors",
+        },
+        jsonSchema: {
+          type: "object",
+          description:
+            "JSON Schema (draft-7 or 2020-12) derived from the block's Zod schema. Required. Used to render CMS forms and validate params.",
+        },
+        previewUrl: {
+          type: "string",
+          description: "Static preview PNG/WEBP URL (customer-hosted)",
+        },
+        previewOrigin: {
+          type: "string",
+          description:
+            "Base URL where the customer serves live previews. CMS iframes this for opt-in live preview.",
+        },
+        sourceCommit: {
+          type: "string",
+          description: "Git SHA or version tag for traceability",
+        },
+      },
+      required: ["project", "slug", "displayName", "jsonSchema"],
+    },
+  },
+
+  execute: (client, args) =>
+    executeTool(args, inputSchema, async (input, { workspaceId, projectSlug }) => {
+      const result = await client.mcpContent.registerBlock.mutate({
+        orgSlug: workspaceId,
+        projectSlug,
+        slug: input.slug,
+        displayName: input.displayName,
+        category: input.category,
+        description: input.description,
+        jsonSchema: input.jsonSchema,
+        previewUrl: input.previewUrl,
+        previewOrigin: input.previewOrigin,
+        sourceCommit: input.sourceCommit,
+      });
+
+      return success({ registered: true, block: result });
+    }),
+};

--- a/packages/mcp-content/src/tools/validateBlockParams.ts
+++ b/packages/mcp-content/src/tools/validateBlockParams.ts
@@ -1,0 +1,69 @@
+/**
+ * validateBlockParams MCP Tool
+ *
+ * Dry-run validate params against a block's registered JSON Schema. Used by AI
+ * agents before committing entry updates to avoid failed saves.
+ */
+
+import { z } from "zod";
+import {
+  executeTool,
+  projectInputProperty,
+  projectSchema,
+  success,
+} from "../base-tool.js";
+import type { Tool } from "../types/index.js";
+
+const inputSchema = projectSchema.extend({
+  slug: z
+    .string()
+    .min(2)
+    .max(64)
+    .regex(/^[a-z][a-z0-9-]*$/),
+  params: z.unknown(),
+  locale: z.string().min(2).max(10).optional(),
+});
+
+export const validateBlockParams: Tool = {
+  definition: {
+    name: "validateBlockParams",
+    description: `Dry-run validate block params against the registered JSON Schema.
+
+Call this before createContentEntry/updateContentEntry to catch invalid params without side effects. Returns { valid: true } or { valid: false, errors: [...] } with per-field paths and expected values.
+
+Critical for agent retry loops: validate → fix errors → validate → commit. Prevents silent corruption of content entries.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectInputProperty,
+        slug: {
+          type: "string",
+          description: "Block slug to validate against",
+        },
+        params: {
+          type: "object",
+          description: "The params object to validate (any shape)",
+        },
+        locale: {
+          type: "string",
+          description:
+            "Optional locale — reserved for future per-locale schema variants",
+        },
+      },
+      required: ["project", "slug", "params"],
+    },
+  },
+
+  execute: (client, args) =>
+    executeTool(args, inputSchema, async (input, { workspaceId, projectSlug }) => {
+      const result = await client.mcpContent.validateBlockParams.query({
+        orgSlug: workspaceId,
+        projectSlug,
+        slug: input.slug,
+        params: input.params,
+        locale: input.locale,
+      });
+
+      return success(result);
+    }),
+};

--- a/packages/mcp-types/src/client-types.ts
+++ b/packages/mcp-types/src/client-types.ts
@@ -48,6 +48,59 @@ import type {
 } from "./content-schemas";
 
 import type {
+  RegisterBlockInput,
+  BulkRegisterBlocksInput,
+  ListBlocksInput,
+  GetBlockInput,
+  ValidateBlockParamsInput,
+  DeleteBlockInput,
+} from "./content-block-schemas";
+
+// —————————————————————————————————————————————————————————————————————————————
+// Block catalog response shapes (see BETTER-246 / BETTER-247)
+// —————————————————————————————————————————————————————————————————————————————
+
+export interface BlockSummaryResponse {
+  id: string;
+  slug: string;
+  displayName: string;
+  category: string | null;
+  registeredAt: string | Date;
+  updatedAt: string | Date;
+}
+
+export interface BulkRegisterBlocksResponse {
+  registered: number;
+  blocks: BlockSummaryResponse[];
+}
+
+export interface BlockDetailResponse {
+  slug: string;
+  displayName: string;
+  category: string | null;
+  description: string | null;
+  paramsSchema: Record<string, unknown>;
+  previewUrl: string | null;
+  previewOrigin: string | null;
+  sourceCommit?: string | null;
+  registeredAt: string | Date;
+  updatedAt: string | Date;
+}
+
+export interface ListBlocksResponse {
+  blocks: BlockDetailResponse[];
+}
+
+export interface ValidateBlockParamsResponse {
+  valid: boolean;
+  errors?: Array<{ path: string; message: string; expected?: unknown }>;
+}
+
+export interface DeleteBlockResponse {
+  deleted: boolean;
+}
+
+import type {
   ListProjectsResponse,
   GetAllTranslationsResponse,
   AddLanguagesResponse,
@@ -281,6 +334,30 @@ export interface MCPContentClient {
     mutate: (
       input: ReorderFieldsInput,
     ) => Promise<CompactReorderFieldsResponse>;
+  };
+
+  // Block catalog (BETTER-246 / BETTER-247)
+  registerBlock: {
+    mutate: (input: RegisterBlockInput) => Promise<BlockSummaryResponse>;
+  };
+  bulkRegisterBlocks: {
+    mutate: (
+      input: BulkRegisterBlocksInput,
+    ) => Promise<BulkRegisterBlocksResponse>;
+  };
+  listBlocks: {
+    query: (input: ListBlocksInput) => Promise<ListBlocksResponse>;
+  };
+  getBlock: {
+    query: (input: GetBlockInput) => Promise<BlockDetailResponse>;
+  };
+  validateBlockParams: {
+    query: (
+      input: ValidateBlockParamsInput,
+    ) => Promise<ValidateBlockParamsResponse>;
+  };
+  deleteBlock: {
+    mutate: (input: DeleteBlockInput) => Promise<DeleteBlockResponse>;
   };
 }
 

--- a/packages/mcp-types/src/content-block-schemas.ts
+++ b/packages/mcp-types/src/content-block-schemas.ts
@@ -1,0 +1,118 @@
+/**
+ * Zod input schemas for Block Catalog MCP tools.
+ *
+ * Blocks are code-first renderable primitives (hero, feature grid, cover, FAQ, CTA, etc.)
+ * defined by the customer's SDK client via `defineBlock()`. These schemas validate the
+ * inputs for registering, listing, getting, validating, and deleting blocks.
+ *
+ * All inputs extend `projectIdentifierSchema` (orgSlug + projectSlug) for tenant scoping.
+ *
+ * See BETTER-246 (platform) and BETTER-247 (MCP tools).
+ */
+
+import { z } from "zod";
+import { projectIdentifierSchema } from "./schemas";
+
+// —————————————————————————————————————————————————————————————————————————————
+// Shared primitives
+// —————————————————————————————————————————————————————————————————————————————
+
+/** Block slug — unique per project. Kebab-case, 2–64 chars. */
+const blockSlug = z
+  .string()
+  .min(2)
+  .max(64)
+  .regex(/^[a-z][a-z0-9-]*$/, "Slug must be lowercase letters/numbers/hyphens, starting with a letter")
+  .describe("Block slug (kebab-case, unique per project). Example: 'cover-gradient'");
+
+/** Raw JSON Schema object — validated at runtime by Ajv against the draft-07 metaschema. */
+const jsonSchemaObject = z
+  .record(z.string(), z.unknown())
+  .describe(
+    "JSON Schema (draft-07 or 2020-12) derived from the block's Zod schema. Required. Used to render CMS forms + validate params.",
+  );
+
+/** Payload shared by single and bulk register endpoints. */
+const blockDefinitionPayload = z.object({
+  slug: blockSlug,
+  displayName: z.string().min(1).max(120),
+  category: z
+    .string()
+    .max(64)
+    .optional()
+    .describe("Grouping label for the picker (e.g. 'cover', 'marketing')"),
+  description: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Help text shown to editors in the block picker"),
+  jsonSchema: jsonSchemaObject,
+  previewUrl: z
+    .string()
+    .url()
+    .optional()
+    .describe("Static preview PNG/WEBP URL. Customer-hosted; Better only stores the reference."),
+  previewOrigin: z
+    .string()
+    .url()
+    .optional()
+    .describe(
+      "Base URL where the customer serves live previews — CMS iframes this for opt-in live preview.",
+    ),
+  sourceCommit: z.string().max(64).optional(),
+});
+
+// —————————————————————————————————————————————————————————————————————————————
+// Tool inputs
+// —————————————————————————————————————————————————————————————————————————————
+
+/** `registerBlock` — upsert a single block by (project, slug). */
+export const registerBlockInput = projectIdentifierSchema.merge(blockDefinitionPayload);
+export type RegisterBlockInput = z.infer<typeof registerBlockInput>;
+
+/** `bulkRegisterBlocks` — register up to 50 blocks atomically in one call. */
+export const bulkRegisterBlocksInput = projectIdentifierSchema.extend({
+  blocks: z.array(blockDefinitionPayload).min(1).max(50),
+});
+export type BulkRegisterBlocksInput = z.infer<typeof bulkRegisterBlocksInput>;
+
+/** `listBlocks` — browse the catalog with optional category/search filters. */
+export const listBlocksInput = projectIdentifierSchema.extend({
+  category: z.string().optional(),
+  search: z
+    .string()
+    .optional()
+    .describe("Case-insensitive substring match on slug, displayName, or description"),
+});
+export type ListBlocksInput = z.infer<typeof listBlocksInput>;
+
+/** `getBlock` — fetch a single block's full detail (including JSON Schema). */
+export const getBlockInput = projectIdentifierSchema.extend({
+  slug: blockSlug,
+});
+export type GetBlockInput = z.infer<typeof getBlockInput>;
+
+/**
+ * `validateBlockParams` — dry-run validate params against a block's JSON Schema.
+ * Used by AI agents before committing entry updates to avoid failed saves.
+ */
+export const validateBlockParamsInput = projectIdentifierSchema.extend({
+  slug: blockSlug,
+  params: z.unknown(),
+  locale: z.string().min(2).max(10).optional(),
+});
+export type ValidateBlockParamsInput = z.infer<typeof validateBlockParamsInput>;
+
+/**
+ * `deleteBlock` — remove a block from the catalog.
+ *
+ * Policy controls what happens to existing content entries referencing the block:
+ * - `strict` (default): fail if any entry uses it
+ * - `warn`: delete + mark affected entries with a warning flag
+ * - `orphan`: delete; entries keep raw data but render nothing for this block type
+ */
+export const deleteBlockInput = projectIdentifierSchema.extend({
+  slug: blockSlug,
+  policy: z.enum(["strict", "warn", "orphan"]).default("strict"),
+});
+export type DeleteBlockInput = z.infer<typeof deleteBlockInput>;

--- a/packages/mcp-types/src/index.ts
+++ b/packages/mcp-types/src/index.ts
@@ -28,3 +28,6 @@ export * from "./content-types";
 
 // Re-export content compact types
 export * from "./content-compact-types";
+
+// Re-export block catalog schemas (BETTER-246 / BETTER-247)
+export * from "./content-block-schemas";


### PR DESCRIPTION
## Summary

Adds six new MCP tools for managing the per-project **block catalog** — code-first renderable primitives (hero, feature grid, cover, FAQ, CTA) registered via the customer's SDK and composed by AI agents.

Part of the [BETTER-246](https://linear.app/aliosman/issue/BETTER-246) / [BETTER-247](https://linear.app/aliosman/issue/BETTER-247) blocks platform work.

## New tools

| Tool | Type | Purpose |
|------|------|---------|
| \`registerBlock\` | write | Upsert single block by (project, slug) |
| \`bulkRegisterBlocks\` | write | Register up to 50 blocks atomically |
| \`listBlocks\` | read | Browse catalog with category/search filters |
| \`getBlock\` | read | Single block detail with paramsSchema |
| \`validateBlockParams\` | read | Dry-run validate params vs JSON Schema |
| \`deleteBlock\` | destructive | Remove from catalog (policies: strict/warn/orphan) |

## Security invariant

**No customer render code ever enters Better's infrastructure.** Tools store only:
- JSON Schema (derived from the customer's Zod via \`z.toJSONSchema()\`)
- Metadata (displayName, category, description)
- Optional static preview PNG URL (customer-hosted)
- Optional iframe preview origin (customer-hosted, sandboxed)

Render happens in the customer's app via \`<BlockRenderer block={...} registry={...} />\` — zero runtime dependency on Better.

## Paired platform changes

- \`block_catalog\` Postgres table (indexed per-project, unique slug per project)
- \`mcpContent.{register,bulkRegister,list,get,validate,delete}Block\` tRPC procedures
- Ajv-compatible validation via \`@cfworker/json-schema\` (Workers-native, no dynamic code compilation)

## Dogfooding

Reference implementation: Helpway landing blog covers. Six \`defineBlock()\` instances (\`cover-logo\`, \`cover-gradient\`, \`cover-preview-{trace,analytics,inbox,knowledge}\`) migrated from 7 flat CMS fields to a single block-based \`cover\` field.

## Test plan

- [ ] \`bulkRegisterBlocks\` with 6 blocks → 200 OK, all slugs returned
- [ ] \`listBlocks\` returns the 6 blocks with full paramsSchema
- [ ] \`getBlock\` returns single detail
- [ ] \`validateBlockParams\` — happy path returns \`{ valid: true }\`
- [ ] \`validateBlockParams\` — sad path returns \`{ valid: false, errors: [...] }\` with actionable per-field paths
- [ ] \`registerBlock\` upsert conflict updates in place
- [ ] \`deleteBlock\` removes row

Local integration tested against platform dev server (port 52490).