### PR TITLE
test: Tier 2 — green expo backend + mcp-content schema tests (BETTER-249)

### DIFF
--- a/packages/expo/src/__tests__/backend.test.ts
+++ b/packages/expo/src/__tests__/backend.test.ts
@@ -32,15 +32,42 @@ const MOCK_NESTED_TRANSLATIONS = {
   },
 };
 
-const createMockFetch = (data: Record<string, unknown> = MOCK_TRANSLATIONS) =>
-  mock(() =>
-    Promise.resolve(
-      new Response(JSON.stringify(data), {
+/**
+ * Minimal manifest payload shared by every test's mock fetch. The SDK's core
+ * `getMessages` fetches the manifest up front to derive a version suffix for
+ * its cache key (see oss/packages/core/src/cdn.ts). Without a valid manifest
+ * response, the derivation falls back to "unversioned" AND the manifest fetch
+ * retries on every call — breaking cache-hit assertions below. Returning a
+ * proper manifest once lets core's TtlCache short-circuit subsequent reads.
+ */
+const buildMockManifest = (locale: string) => ({
+  languages: [{ code: locale, name: locale, isSource: true }],
+  files: {
+    [locale]: {
+      url: `https://cdn.better-i18n.com/acme/app/${locale}/translations.json`,
+      size: 100,
+      lastModified: "2026-01-01T00:00:00.000Z",
+    },
+  },
+  updatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const createMockFetch = (
+  data: Record<string, unknown> = MOCK_TRANSLATIONS,
+  locale = "en",
+) =>
+  mock((input: string | Request | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = url.includes("manifest.json")
+      ? JSON.stringify(buildMockManifest(locale))
+      : JSON.stringify(data);
+    return Promise.resolve(
+      new Response(body, {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      })
-    )
-  );
+      }),
+    );
+  });
 
 const createFailingFetch = () =>
   mock(() =>
@@ -123,7 +150,9 @@ describe("BetterI18nBackend", () => {
 
     const data = await readFromBackend(backend, "en");
     expect(data).toEqual(MOCK_TRANSLATIONS);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // First read: 1 manifest + 1 translations = 2 CDN round-trips.
+    // The manifest fetch feeds the version suffix on the messages cache key.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("should serve from memory cache on second read", async () => {
@@ -137,8 +166,9 @@ describe("BetterI18nBackend", () => {
     await readFromBackend(backend, "en");
     await readFromBackend(backend, "en");
 
-    // Only one CDN fetch (second read from memory cache)
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // First read: 2 fetches (manifest + translations). Second read: 0 —
+    // manifest and messages both served from their TtlCache.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("should fall back to persistent cache when CDN is down", async () => {
@@ -164,7 +194,10 @@ describe("BetterI18nBackend", () => {
 
     const data = await readFromBackend(backend2, "en");
     expect(data).toEqual(MOCK_TRANSLATIONS);
-    expect(failingFetch).toHaveBeenCalledTimes(1);
+    // Fall-back path: core tries the manifest first, it 500s; core then tries
+    // the messages file, it 500s too; both fall through to the persistent
+    // storage written by backend1's successful read. Two CDN attempts.
+    expect(failingFetch).toHaveBeenCalledTimes(2);
   });
 
   it("should always get fresh data from CDN after app restart", async () => {
@@ -194,7 +227,9 @@ describe("BetterI18nBackend", () => {
 
     const data = await readFromBackend(backend2, "en");
     expect(data).toEqual(updatedTranslations);
-    expect(updatedFetch).toHaveBeenCalledTimes(1);
+    // Post-restart the caches are empty, so the new backend must re-fetch
+    // both the manifest (for version) and the translations payload.
+    expect(updatedFetch).toHaveBeenCalledTimes(2);
   });
 
   it("should throw when CDN fails and no cache exists", async () => {
@@ -316,17 +351,44 @@ describe("BetterI18nBackend", () => {
 
   it("should handle different languages independently", async () => {
     const trTranslations = { welcome: "Hosgeldiniz" };
-    let callCount = 0;
-    const multiFetch = mock((url: string) => {
-      callCount++;
-      const data = (url as string).includes("/tr/")
-        ? trTranslations
-        : MOCK_TRANSLATIONS;
+    let translationFetches = 0;
+    const multiFetch = mock((input: string | Request | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      // Manifest serves both locales; version is shared so every messages
+      // fetch reuses the manifest's TtlCache hit on subsequent calls.
+      if (url.includes("manifest.json")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              languages: [
+                { code: "en", name: "English", isSource: true },
+                { code: "tr", name: "Turkish", isSource: false },
+              ],
+              files: {
+                en: {
+                  url: "https://cdn.better-i18n.com/acme/app/en/translations.json",
+                  size: 100,
+                  lastModified: "2026-01-01T00:00:00.000Z",
+                },
+                tr: {
+                  url: "https://cdn.better-i18n.com/acme/app/tr/translations.json",
+                  size: 100,
+                  lastModified: "2026-01-01T00:00:00.000Z",
+                },
+              },
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      translationFetches++;
+      const data = url.includes("/tr/") ? trTranslations : MOCK_TRANSLATIONS;
       return Promise.resolve(
         new Response(JSON.stringify(data), {
           status: 200,
           headers: { "Content-Type": "application/json" },
-        })
+        }),
       );
     });
 
@@ -342,7 +404,9 @@ describe("BetterI18nBackend", () => {
 
     expect(enData).toEqual(MOCK_TRANSLATIONS);
     expect(trData).toEqual(trTranslations);
-    expect(callCount).toBe(2);
+    // Count only translation fetches — one per locale. The shared manifest
+    // is served from TtlCache after the first call across both locales.
+    expect(translationFetches).toBe(2);
   });
 });
 

--- a/packages/mcp-content/src/__tests__/schema-alignment.test.ts
+++ b/packages/mcp-content/src/__tests__/schema-alignment.test.ts
@@ -90,11 +90,27 @@ import type {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Extract the shape of a Zod schema (for .extend-based objects) */
-function zodKeys(schema: z.ZodTypeAny): string[] {
-  if (schema instanceof z.ZodObject) {
-    return Object.keys(schema.shape);
-  }
+/**
+ * Extract the shape of a Zod schema.
+ *
+ * The parameter is typed as `unknown` on purpose: this test file's local `z`
+ * import can be a different realm/version than the one used to build
+ * `@better-i18n/mcp-types` (common when workspace packages pin different
+ * Zod majors, e.g. v3 vs v4). Typing against `z.ZodTypeAny` forces
+ * cross-realm assignability, which TypeScript rejects. We probe structurally
+ * at runtime — same reason `instanceof z.ZodObject` also can't be used here.
+ */
+function zodKeys(schema: unknown): string[] {
+  const s = schema as {
+    shape?: Record<string, unknown>;
+    def?: { shape?: Record<string, unknown> };
+    _def?: { shape?: () => Record<string, unknown> };
+    constructor?: { name?: string };
+  };
+  if (s?.constructor?.name !== "ZodObject") return [];
+  if (s.shape && typeof s.shape === "object") return Object.keys(s.shape);
+  if (s.def?.shape && typeof s.def.shape === "object") return Object.keys(s.def.shape);
+  if (typeof s._def?.shape === "function") return Object.keys(s._def.shape());
   return [];
 }
 


### PR DESCRIPTION
## Summary

Tier 2 of BETTER-249. Fixes **13 of 15** test failures that remained after Tier 1's lint/config cleanup (#139). The **2 remaining** are an unrelated pre-existing React-19 compatibility issue in `@better-i18n/ui@0.1.1` — separate scope, logged below.

### Before → After (against clean main)

| | Before | After |
|---|---|---|
| fail | 13 | **0** |
| errors | 2 | 2 (unrelated) |

## Fix 1 — expo backend tests (5 assertions)

`packages/expo/src/__tests__/backend.test.ts`

The SWR revalidation shipped in #135 added an up-front manifest fetch to every `getMessages` call. The existing mock returned translations data for EVERY URL (including `manifest.json`), so every call looked like "manifest request fails → fallback → translations request succeeds" — two CDN round-trips where assertions expected one.

**Fix.** `createMockFetch` now returns a valid manifest when the URL contains `manifest.json`, translations otherwise. Call-count assertions updated to the new steady-state:
- First read: 2 round-trips (manifest + translations)
- Second read: 0 — both TtlCache hits

Multi-locale test swapped its ad-hoc fetch mock for a URL-aware one that shares a manifest across locales (matches production behavior: manifest is one file listing all languages).

## Fix 2 — mcp-content schema-alignment helper (6 assertions)

`packages/mcp-content/src/__tests__/schema-alignment.test.ts`

`zodKeys` used `schema instanceof z.ZodObject`. When `@better-i18n/mcp-types` links a different Zod realm/version than this test file's local import (common in workspaces with mixed Zod v3/v4), `instanceof` returns false across realms even though the class name matches. The helper silently returned `[]` for every mcp-types schema — six assertions that compared tool vs mcp-types key lists were effectively no-ops producing wrong-negatives.

**Fix.** Replaced `instanceof` with a structural probe: check `constructor.name === "ZodObject"` then try `.shape`, `.def.shape`, `._def.shape()` in order. Works against both Zod v3 and v4, same realm or not. Parameter typed as `unknown` to stop TypeScript demanding cross-realm assignability.

## Out of scope — 2 remaining failures

Both trip over the same error raised while bun tries to load a transitive dependency:

```
packages/server/src/__tests__/createServerI18n.test.ts
packages/server/src/__tests__/better-auth-provider.test.ts

# Unhandled error between tests
SyntaxError: Export named 'isValidElement' not found in module
  /node_modules/.bun/react@19.2.4/node_modules/react/index.js
```

Root cause: `@better-i18n/ui@0.1.1` uses `React.isValidElement` via the default React import, which React 19 no longer exposes as a named export of the default module. Unrelated to CI hygiene or SWR refactor. Will file as a separate ticket.

## Test plan

- [x] `bun test` locally against clean main: 13 fail + 2 errors
- [x] `bun test` locally on this branch: 0 fail + 2 errors (same 2 unrelated errors)
- [x] Each touched package passes in isolation: `bun test packages/expo` (0 fail) · `bun test packages/mcp-content` (0 fail)
- [ ] CI Test job: expected to match local — only the `@better-i18n/ui` React-19 errors remain
- [ ] CI Lint & Typecheck job: already green from Tier 1

## Closes

Partially BETTER-249 (Tier 2 of 3). Follow-ups:
- New ticket for `@better-i18n/ui` + React 19 compat (Tier 2b)
- Tier 3: rule modernization (deprecated typescript-eslint rules) — nice-to-have