### PR TITLE
feat(landing): LCP perf fixes + helpway widget refactor + UI/i18n polish

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -19,6 +19,7 @@
     "@better-i18n/ui": "^0.2.0",
     "@better-i18n/use-intl": "workspace:*",
     "@central-icons-react/round-outlined-radius-2-stroke-2": "^1.1.90",
+    "@helpway/react": "^0.3.1",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@remotion/player": "^4.0.450",
     "@tailwindcss/vite": "^4.1.18",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -19,7 +19,7 @@
     "@better-i18n/ui": "^0.2.0",
     "@better-i18n/use-intl": "workspace:*",
     "@central-icons-react/round-outlined-radius-2-stroke-2": "^1.1.90",
-    "@helpway/react": "^0.3.2",
+    "@helpway/react": "0.3.2",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@remotion/player": "^4.0.450",
     "@tailwindcss/vite": "^4.1.18",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -19,7 +19,7 @@
     "@better-i18n/ui": "^0.2.0",
     "@better-i18n/use-intl": "workspace:*",
     "@central-icons-react/round-outlined-radius-2-stroke-2": "^1.1.90",
-    "@helpway/react": "0.3.2",
+    "@helpway/react": "0.3.4",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@remotion/player": "^4.0.450",
     "@tailwindcss/vite": "^4.1.18",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -19,7 +19,7 @@
     "@better-i18n/ui": "^0.2.0",
     "@better-i18n/use-intl": "workspace:*",
     "@central-icons-react/round-outlined-radius-2-stroke-2": "^1.1.90",
-    "@helpway/react": "^0.3.1",
+    "@helpway/react": "^0.3.2",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@remotion/player": "^4.0.450",
     "@tailwindcss/vite": "^4.1.18",

--- a/apps/landing/src/components/Features.tsx
+++ b/apps/landing/src/components/Features.tsx
@@ -1,474 +1,26 @@
-import { useState, useEffect } from "react";
-import { cn } from "@better-i18n/ui/lib/utils";
-import { useT } from "@/lib/i18n";
+/**
+ * Features section — orchestrates the three product showcase cards.
+ *
+ * Each card mirrors a real, named UI surface from the better-i18n
+ * platform dashboard:
+ *
+ *   - features/AIFeatureCard.tsx       AI tool-call (proposeTranslations)
+ *   - features/PublishFeatureCard.tsx  Sync activity log + status summary
+ *   - features/McpFeatureCard.tsx      MCP IDE setup (Cursor / Claude / etc.)
+ *
+ * Cards animate only while in viewport (useDemoLoop), pause off-screen,
+ * and freeze at their final beat under prefers-reduced-motion.
+ */
+
 import { Link, useParams } from "@tanstack/react-router";
-import {
-  IconCircleInfo,
-  IconPageText,
-} from "@central-icons-react/round-outlined-radius-2-stroke-2";
+
 import { SpriteIcon } from "@/components/SpriteIcon";
+import { Stagger, StaggerItem } from "@/components/motion/Stagger";
+import { useT } from "@/lib/i18n";
 
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// 1. AI Translation Feature Card (Brand-Aware Intelligence)
-function AIFeatureCard() {
-  const t = useT("features.ai");
-  const [step, setStep] = useState<
-    "idle" | "processing" | "review" | "completed"
-  >("idle");
-
-  useEffect(() => {
-    let isMounted = true;
-    const runDemo = async () => {
-      if (!isMounted) return;
-      setStep("idle");
-      await sleep(2000);
-      if (!isMounted) return;
-      setStep("processing");
-      await sleep(2000);
-      if (!isMounted) return;
-      setStep("review");
-      await sleep(2500);
-      if (!isMounted) return;
-      setStep("completed");
-      await sleep(3000);
-      if (isMounted) runDemo();
-    };
-    runDemo();
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return (
-    <div className="flex flex-col h-full bg-white border border-mist-200 rounded-2xl overflow-hidden shadow-[0_18px_50px_-40px_rgba(15,23,42,0.35)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
-      <div className="h-[280px] bg-mist-50 relative overflow-hidden p-5 flex flex-col shrink-0">
-        <div className="flex items-center gap-2 text-xs text-mist-700 mb-4 pb-3 border-b border-mist-200">
-          <div className="w-2 h-2 rounded-full bg-mist-400" />
-          <span className="font-bold uppercase tracking-tight text-[10px]">
-            {t("badge", { defaultValue: "AI Translation Engine" })}
-          </span>
-          <div className="ml-auto flex items-center gap-1.5">
-            <span className="text-[9px] text-mist-600">
-              {t("glossaryLabel", { defaultValue: "Glossary" })}
-            </span>
-            <span className="text-[9px] bg-white text-mist-600 px-1.5 py-0.5 rounded border border-mist-200 font-medium">
-              {t("glossaryStatus", { defaultValue: "Active" })}
-            </span>
-          </div>
-        </div>
-
-        <div className="flex-1 space-y-4 overflow-y-auto pr-1">
-          <div className="flex justify-end">
-            <div className="bg-white border border-mist-200 text-mist-900 rounded-lg rounded-tr-none px-3 py-2 text-[11px] max-w-[85%] shadow-sm font-medium">
-              {t("userMessage", {
-                code: "dashboard.sync",
-                defaultValue: "Translate {code} to Turkish",
-              })}
-            </div>
-          </div>
-
-          {step !== "idle" && (
-            <div className="flex justify-start animate-in fade-in slide-in-from-bottom-2 duration-300">
-              <div className="bg-white border border-mist-200 text-mist-950 rounded-lg rounded-tl-none p-3 text-[11px] w-full shadow-md relative overflow-hidden">
-                {step === "processing" ? (
-                  <div className="flex items-center gap-2 text-mist-500 font-medium">
-                    <svg
-                      className="w-3.5 h-3.5 animate-spin"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                      />
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      />
-                    </svg>
-                    {t("processing", {
-                      defaultValue: "Translating with context...",
-                    })}
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    <div className="flex items-center gap-2 mb-1">
-                      <div className="size-4 rounded bg-mist-100 flex items-center justify-center text-mist-600">
-                        <IconCircleInfo className="size-3" />
-                      </div>
-                      <span className="text-[10px] text-mist-700 font-medium italic">
-                        {t("glossaryMatch", {
-                          defaultValue: "Glossary match applied",
-                        })}
-                      </span>
-                    </div>
-                    <div className="p-2.5 rounded-lg bg-mist-50/50 border border-mist-100 space-y-1">
-                      <div className="text-[9px] font-mono text-mist-600">
-                        {t("sourceLabel", { defaultValue: "SOURCE" })}
-                      </div>
-                      <div className="text-[11px] font-semibold text-mist-900 flex items-center gap-1.5">
-                        {t.rich("targetLabel", {
-                          term: (chunks) => (
-                            <span className="text-mist-950 bg-mist-200 px-1 rounded transition-all">
-                              {chunks}
-                            </span>
-                          ),
-                        })}
-                      </div>
-                    </div>
-                    {step === "review" ? (
-                      <div className="flex gap-2">
-                        <div className="flex-1 bg-mist-900 text-white py-1.5 rounded text-[10px] font-semibold text-center cursor-default">
-                          {t("approve", { defaultValue: "Approve" })}
-                        </div>
-                        <div className="px-2 py-1.5 rounded border border-mist-200 bg-white text-mist-600 text-[10px] font-medium text-center cursor-default">
-                          {t("edit", { defaultValue: "Edit" })}
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="text-mist-900 font-bold py-1.5 bg-mist-100 rounded text-[10px] text-center flex items-center justify-center gap-1.5 border border-mist-200 animate-in zoom-in-95 duration-300">
-                        <SpriteIcon name="checkmark" className="size-3" />
-                        {t("brandConsistent", {
-                          defaultValue: "Brand-consistent \u2713",
-                        })}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-      <div className="p-6 flex-1 flex flex-col border-t border-mist-100">
-        <h3 className="text-base font-medium text-mist-950">
-          {t("title", { defaultValue: "AI-Powered, Brand-Aware" })}
-        </h3>
-        <p className="mt-2 text-sm text-mist-700 leading-relaxed">
-          {t("description", {
-            defaultValue:
-              "Translations that understand your brand voice, glossary, and context. Not just word-for-word.",
-          })}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-// 2. Automated Git/CDN Workflow Feature Card
-function PublishFeatureCard() {
-  const t = useT("features.publish");
-  const [status, setStatus] = useState<"idle" | "publishing" | "published">(
-    "idle",
-  );
-  const [elapsedTime, setElapsedTime] = useState(0);
-
-  useEffect(() => {
-    let isMounted = true;
-    const runDemo = async () => {
-      if (!isMounted) return;
-      setStatus("idle");
-      setElapsedTime(0);
-      await sleep(3000);
-      if (!isMounted) return;
-      setStatus("publishing");
-      const timer = setInterval(() => setElapsedTime((t) => t + 1), 1000);
-      await sleep(3000);
-      if (!isMounted) {
-        clearInterval(timer);
-        return;
-      }
-      setStatus("published");
-      clearInterval(timer);
-      await sleep(4000);
-      if (isMounted) runDemo();
-    };
-    runDemo();
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return (
-    <div className="flex flex-col h-full bg-white border border-mist-200 rounded-2xl overflow-hidden shadow-[0_18px_50px_-40px_rgba(15,23,42,0.35)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
-      <div className="h-[280px] bg-mist-50 p-5 flex flex-col shrink-0">
-        <div className="flex items-center justify-between mb-4 pb-3 border-b border-mist-200">
-          <div className="flex items-center gap-2">
-            <div
-              className={cn(
-                "size-1.5 rounded-full",
-                status === "published"
-                  ? "bg-emerald-500"
-                  : status === "publishing"
-                    ? "bg-amber-400 animate-pulse"
-                    : "bg-mist-300",
-              )}
-            />
-            <span className="font-bold uppercase tracking-tight text-[10px] text-mist-600">
-              {status === "idle"
-                ? t("statusReady", { defaultValue: "Ready" })
-                : status === "publishing"
-                  ? t("statusSyncing", { defaultValue: "Syncing..." })
-                  : t("statusSuccess", { defaultValue: "Published" })}
-            </span>
-          </div>
-          <span className="text-[10px] text-mist-600 font-mono">
-            {elapsedTime}s
-          </span>
-        </div>
-
-        <div className="flex-1 flex flex-col gap-2">
-          {/* Artifacts List */}
-          <div className="bg-white rounded-xl border border-mist-200 p-2.5 space-y-2 shadow-sm">
-            <div className="flex items-center justify-between px-0.5">
-              <span className="text-[9px] font-bold text-mist-600 uppercase tracking-widest">
-                {t("cdnArtifacts", { defaultValue: "CDN Artifacts" })}
-              </span>
-              <span className="text-[8px] text-mist-600 font-mono">v1.2.0</span>
-            </div>
-            <div className="space-y-1">
-              {[
-                { f: "locales/tr.json", c: "+12" },
-                { f: "locales/de.json", c: "+8" },
-              ].map((file, i) => (
-                <div
-                  key={i}
-                  className="flex items-center justify-between py-1 px-1.5 rounded bg-mist-50/50 border border-mist-100"
-                >
-                  <div className="flex items-center gap-2">
-                    <IconPageText className="size-3 text-mist-300" />
-                    <span className="text-[10px] text-mist-600 font-mono truncate max-w-[100px]">
-                      {file.f}
-                    </span>
-                  </div>
-                  <span className="text-[9px] text-mist-900 font-bold">
-                    {file.c}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* GitHub Integration - Compact PR Card */}
-          <div
-            className={cn(
-              "rounded-xl border p-2.5 flex flex-col gap-2 transition-all duration-500 shadow-sm relative overflow-hidden",
-              status === "published"
-                ? "bg-white border-mist-200 ring-1 ring-mist-900/5"
-                : "bg-white border-mist-200 opacity-40 grayscale",
-            )}
-          >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <SpriteIcon name="github" className="size-3.5 text-mist-900" />
-                <span className="text-[10px] font-bold text-mist-950">
-                  {t("pullRequest", { defaultValue: "Pull Request" })}
-                </span>
-              </div>
-              <span
-                className={cn(
-                  "text-[8px] px-1.5 py-0.5 rounded font-bold uppercase tracking-wider",
-                  status === "published"
-                    ? "bg-emerald-100 text-emerald-700"
-                    : "bg-mist-100 text-mist-700",
-                )}
-              >
-                {status === "published"
-                  ? t("prStatusOpen", { defaultValue: "Open" })
-                  : t("prStatusQueued", { defaultValue: "Queued" })}
-              </span>
-            </div>
-            <div className="space-y-1">
-              <p className="text-[9px] text-mist-600 font-medium line-clamp-1">
-                {t("prMessage", {
-                  defaultValue: "chore(i18n): sync translations",
-                })}
-              </p>
-              <div className="flex items-center gap-1.5">
-                <div className="size-3 rounded-full bg-mist-200 border border-white" />
-                <span className="text-[8px] text-mist-600 font-medium">
-                  {t("botPushed", {
-                    branch: "i18n-sync",
-                    defaultValue: "bot pushed to {branch}",
-                  })}
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className="p-6 flex-1 flex flex-col border-t border-mist-100">
-        <h3 className="text-base font-medium text-mist-950">
-          {t("title", { defaultValue: "Git-Native Workflow" })}
-        </h3>
-        <p className="mt-2 text-sm text-mist-700 leading-relaxed">
-          {t("description", {
-            defaultValue:
-              "Automatic sync to your repository via pull requests, plus instant CDN delivery for production.",
-          })}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-// 3. Crawler Engine Feature Card (UI-based logs & terminology)
-function AIContextCard() {
-  const t = useT("features.crawler");
-  const [step, setStep] = useState<"scanning" | "extracting" | "syncing">(
-    "scanning",
-  );
-
-  useEffect(() => {
-    let isMounted = true;
-    const runDemo = async () => {
-      if (!isMounted) return;
-      setStep("scanning");
-      await sleep(2500);
-      if (!isMounted) return;
-      setStep("extracting");
-      await sleep(2500);
-      if (!isMounted) return;
-      setStep("syncing");
-      await sleep(4000);
-      if (isMounted) runDemo();
-    };
-    runDemo();
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return (
-    <div className="flex flex-col h-full bg-white border border-mist-200 rounded-2xl overflow-hidden shadow-[0_18px_50px_-40px_rgba(15,23,42,0.35)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
-      <div className="h-[280px] bg-mist-50 p-5 flex flex-col shrink-0 relative">
-        <div className="flex items-center justify-between mb-4 pb-3 border-b border-mist-200">
-          <div className="flex items-center gap-2">
-            <div className="size-1.5 rounded-full bg-mist-900 animate-pulse" />
-            <span className="text-[10px] font-bold text-mist-700 uppercase tracking-tight">
-              {t("badge", { defaultValue: "Context Crawler" })}
-            </span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <span className="text-[9px] text-mist-600 font-medium">
-              {t("pagesLabel", { defaultValue: "Pages" })}
-            </span>
-            <span className="text-[9px] font-bold text-mist-900 font-mono">
-              12/12
-            </span>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-xl border border-mist-200 shadow-lg overflow-hidden flex-1 flex flex-col">
-          <div className="p-3 bg-mist-50/50 border-b border-mist-100 flex-1 overflow-hidden">
-            <div className="text-[9px] font-bold text-mist-600 uppercase tracking-widest mb-3">
-              {t("activityLog", { defaultValue: "Activity Log" })}
-            </div>
-            <div className="space-y-2.5">
-              <div className="flex items-start gap-2.5">
-                <div className="size-4 rounded-full bg-blue-50 border border-blue-100 flex items-center justify-center shrink-0 mt-0.5">
-                  <div className="size-1.5 rounded-full bg-blue-500 animate-pulse" />
-                </div>
-                <div className="space-y-1">
-                  <p className="text-[10px] font-bold text-mist-900 leading-none">
-                    {t("syncStarted", { defaultValue: "Sync Started" })}
-                  </p>
-                  <p className="text-[9px] text-mist-700 leading-normal">
-                    {t("syncMessage", {
-                      defaultValue:
-                        "Crawling your website for translation context...",
-                    })}
-                  </p>
-                </div>
-              </div>
-
-              <div
-                className={cn(
-                  "flex items-start gap-2.5 transition-all duration-500",
-                  step === "extracting" || step === "syncing"
-                    ? "opacity-100 translate-x-0"
-                    : "opacity-0 -translate-x-2",
-                )}
-              >
-                <div className="size-4 rounded-full bg-blue-50 border border-blue-100 flex items-center justify-center shrink-0 mt-0.5">
-                  <div className="size-1.5 rounded-full bg-blue-500" />
-                </div>
-                <div className="space-y-1">
-                  <p className="text-[10px] font-bold text-mist-900 leading-none">
-                    {t("extractingTerms", { defaultValue: "Extracting Terms" })}
-                  </p>
-                  <p className="text-[9px] text-mist-700 leading-normal">
-                    {t("extractingMessage", {
-                      defaultValue: "Building glossary from your content...",
-                    })}
-                  </p>
-                </div>
-              </div>
-
-              <div
-                className={cn(
-                  "flex items-start gap-2.5 transition-all duration-500",
-                  step === "syncing"
-                    ? "opacity-100 translate-x-0"
-                    : "opacity-0 -translate-x-2",
-                )}
-              >
-                <div className="size-4 rounded-full bg-emerald-50 border border-emerald-100 flex items-center justify-center shrink-0 mt-0.5">
-                  <SpriteIcon name="checkmark" className="size-2.5 text-emerald-600" />
-                </div>
-                <div className="space-y-1">
-                  <p className="text-[10px] font-bold text-mist-900 leading-none">
-                    {t("manifestUploaded", {
-                      defaultValue: "Manifest Uploaded",
-                    })}
-                  </p>
-                  <p className="text-[9px] text-mist-700 leading-normal">
-                    {t("manifestMessage", {
-                      defaultValue:
-                        "Context manifest ready for AI translations",
-                    })}
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="p-2.5 bg-white flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className="size-1.5 rounded-full bg-emerald-500" />
-              <span className="text-[9px] font-bold text-mist-900">
-                {t("analysisApproved", { defaultValue: "Analysis Approved" })}
-              </span>
-            </div>
-            <span className="text-[9px] text-mist-600 font-mono">
-              better-i18n.com
-            </span>
-          </div>
-        </div>
-      </div>
-      <div className="p-6 flex-1 flex flex-col border-t border-mist-100">
-        <h3 className="text-base font-medium text-mist-950">
-          {t("title", { defaultValue: "Understands Your Product" })}
-        </h3>
-        <p className="mt-2 text-sm text-mist-700 leading-relaxed">
-          {t("description", {
-            defaultValue:
-              "Our crawler analyzes your website to build context, glossaries, and terminology — so translations are always accurate.",
-          })}
-        </p>
-      </div>
-    </div>
-  );
-}
+import { AIFeatureCard } from "./features/AIFeatureCard";
+import { McpFeatureCard } from "./features/McpFeatureCard";
+import { PublishFeatureCard } from "./features/PublishFeatureCard";
 
 export default function Features() {
   const t = useT("features");
@@ -480,15 +32,15 @@ export default function Features() {
         <div className="flex flex-col gap-12">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div className="max-w-2xl">
-              <h2 className="font-display text-3xl/[1.08] font-medium tracking-[-0.03em] text-mist-950 sm:text-4xl/[1.04]">
+              <h2 className="font-display text-3xl/[1.08] font-medium tracking-[-0.03em] text-mist-950 sm:text-4xl/[1.04] text-balance">
                 {t("title", {
-                  defaultValue: "Everything you need to ship globally",
+                  defaultValue: "Küresel ölçekte yayınlamak için tek platform.",
                 })}
               </h2>
-              <p className="mt-4 text-lg text-mist-600">
+              <p className="mt-4 text-lg text-mist-600 text-pretty">
                 {t("subtitle", {
                   defaultValue:
-                    "A complete localization platform built for modern development workflows.",
+                    "Çevirin. Yönetin. Yayınlayın. Tüm dilleri tek panelden kontrol edin.",
                 })}
               </p>
             </div>
@@ -497,16 +49,22 @@ export default function Features() {
               params={{ locale: locale || "en" }}
               className="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-mist-700 hover:text-mist-950 transition-colors"
             >
-              {t("seeHowItWorks", { defaultValue: "See how it works" })}
+              {t("seeHowItWorks", { defaultValue: "Nasıl çalıştığını görün" })}
               <SpriteIcon name="arrow-right" className="w-4 h-4" />
             </Link>
           </div>
 
-          <div className="grid grid-cols-1 gap-5 lg:grid-cols-3 items-stretch">
-            <AIFeatureCard />
-            <PublishFeatureCard />
-            <AIContextCard />
-          </div>
+          <Stagger className="grid grid-cols-1 gap-5 lg:grid-cols-3 items-stretch">
+            <StaggerItem className="h-full">
+              <AIFeatureCard />
+            </StaggerItem>
+            <StaggerItem className="h-full">
+              <PublishFeatureCard />
+            </StaggerItem>
+            <StaggerItem className="h-full">
+              <McpFeatureCard />
+            </StaggerItem>
+          </Stagger>
         </div>
       </div>
     </section>

--- a/apps/landing/src/components/Header.tsx
+++ b/apps/landing/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import { Link, useParams } from "@tanstack/react-router";
 
 import { cn } from "@better-i18n/ui/lib/utils";
@@ -17,7 +18,10 @@ import { SpriteIcon } from "@/components/SpriteIcon";
 import { useT } from "@/lib/i18n";
 import { useQuery } from "@tanstack/react-query";
 import { LanguageSwitcher } from "./LanguageSwitcher";
-import { MobileNav } from "./MobileNav";
+
+const LazyMobileNav = lazy(() =>
+  import("./MobileNav").then((m) => ({ default: m.MobileNav })),
+);
 
 // Featured integrations shown in the nav dropdown
 const NAV_INTEGRATIONS: Array<{
@@ -748,7 +752,21 @@ export default function Header({ className }: { className?: string }) {
               </a>
             </div>
           </div>
-          <MobileNav />
+          <Suspense
+            fallback={
+              <div className="lg:hidden">
+                <div className="flex size-10 items-center justify-center rounded-lg text-mist-950">
+                  <svg className="size-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 5h16" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 12h16" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 19h16" />
+                  </svg>
+                </div>
+              </div>
+            }
+          >
+            <LazyMobileNav />
+          </Suspense>
         </div>
       </nav>
     </header>

--- a/apps/landing/src/components/Hero.tsx
+++ b/apps/landing/src/components/Hero.tsx
@@ -1,7 +1,22 @@
+import { lazy, Suspense } from "react";
 import { useT } from "@/lib/i18n";
 import { Link, useParams } from "@tanstack/react-router";
-import { Demo } from "../demo";
 import { SpriteIcon } from "@/components/SpriteIcon";
+
+const LazyDemo = lazy(() =>
+  import("../demo").then((m) => ({ default: m.Demo })),
+);
+
+function DemoSkeleton() {
+  return (
+    <div className="w-full h-full animate-pulse bg-mist-100 rounded-lg flex items-center justify-center">
+      <div className="text-center space-y-3">
+        <div className="h-3 w-32 bg-mist-200 rounded mx-auto" />
+        <div className="h-3 w-24 bg-mist-200 rounded mx-auto" />
+      </div>
+    </div>
+  );
+}
 
 export default function Hero() {
   const t = useT("hero");
@@ -68,7 +83,9 @@ export default function Hero() {
                 "0 28px 70px rgba(0, 0, 0, 0.25), 0 14px 32px rgba(0, 0, 0, 0.15)",
             }}
           >
-            <Demo />
+            <Suspense fallback={<DemoSkeleton />}>
+              <LazyDemo />
+            </Suspense>
           </div>
         </div>
 
@@ -83,7 +100,9 @@ export default function Hero() {
               height: "600px",
             }}
           >
-            <Demo />
+            <Suspense fallback={<DemoSkeleton />}>
+              <LazyDemo />
+            </Suspense>
           </div>
         </div>
       </div>

--- a/apps/landing/src/components/Hero.tsx
+++ b/apps/landing/src/components/Hero.tsx
@@ -1,22 +1,7 @@
-import { lazy, Suspense } from "react";
 import { useT } from "@/lib/i18n";
 import { Link, useParams } from "@tanstack/react-router";
+import { Demo } from "../demo";
 import { SpriteIcon } from "@/components/SpriteIcon";
-
-const LazyDemo = lazy(() =>
-  import("../demo").then((m) => ({ default: m.Demo })),
-);
-
-function DemoSkeleton() {
-  return (
-    <div className="w-full h-full animate-pulse bg-mist-100 rounded-lg flex items-center justify-center">
-      <div className="text-center space-y-3">
-        <div className="h-3 w-32 bg-mist-200 rounded mx-auto" />
-        <div className="h-3 w-24 bg-mist-200 rounded mx-auto" />
-      </div>
-    </div>
-  );
-}
 
 export default function Hero() {
   const t = useT("hero");
@@ -83,9 +68,7 @@ export default function Hero() {
                 "0 28px 70px rgba(0, 0, 0, 0.25), 0 14px 32px rgba(0, 0, 0, 0.15)",
             }}
           >
-            <Suspense fallback={<DemoSkeleton />}>
-              <LazyDemo />
-            </Suspense>
+            <Demo />
           </div>
         </div>
 
@@ -100,9 +83,7 @@ export default function Hero() {
               height: "600px",
             }}
           >
-            <Suspense fallback={<DemoSkeleton />}>
-              <LazyDemo />
-            </Suspense>
+            <Demo />
           </div>
         </div>
       </div>

--- a/apps/landing/src/components/Pricing.tsx
+++ b/apps/landing/src/components/Pricing.tsx
@@ -1,7 +1,6 @@
 import { cn } from "@better-i18n/ui/lib/utils";
 import { useT } from "@/lib/i18n";
 import { useState } from "react";
-import { SpriteIcon } from "@/components/SpriteIcon";
 import { type PricingPlan, getDisplayPrice } from "@/lib/content";
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -12,9 +11,11 @@ type BillingPeriod = "monthly" | "yearly";
 
 const limitLabelDefaults: Record<string, string> = {
   projects: "Projects",
+  translationKeys: "Translation keys",
   aiMessages: "AI messages",
   glossaryTerms: "Glossary terms",
   contentItems: "Content items",
+  publishes: "Publishes",
 };
 
 const featureLabelDefaults: Record<string, string> = {
@@ -26,25 +27,11 @@ const featureLabelDefaults: Record<string, string> = {
   analytics: "Analytics",
   teamMembers: "Team members",
   contentCms: "Content CMS",
-  aiTranslationAnalysisSuggestions: "AI translation analysis suggestions",
+  aiTranslationAnalysisSuggestions: "AI translation suggestions",
   sso: "SSO",
   dedicatedAccountManager: "Dedicated account manager",
   slaGuarantee: "SLA guarantee",
 };
-
-// ─── Sub-components ──────────────────────────────────────────────────
-
-function FeatureIndicator({ enabled }: { enabled: boolean }) {
-  return enabled ? (
-    <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-mist-950 text-white">
-      <SpriteIcon name="checkmark" className="h-3.5 w-3.5" />
-    </span>
-  ) : (
-    <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-mist-200 text-xs font-medium text-mist-300">
-      -
-    </span>
-  );
-}
 
 /**
  * Format a price for display.
@@ -77,29 +64,51 @@ export default function Pricing({
   // If no CMS plans provided, render nothing (data should come from loader)
   if (!plans || plans.length === 0) return null;
 
+  // Diff-based feature display: each plan after the first only shows what's NEW
+  // vs. the previous tier — eliminates duplicate scanning, lets numeric limits
+  // do the real differentiation work above.
+  const featureRowsByPlan = plans.map((plan, idx) => {
+    const includedNow = plan.features.filter((f) => f.included);
+    if (idx === 0) {
+      return { items: includedNow, prevPlanName: null as string | null };
+    }
+    const prevIncluded = new Set(
+      plans[idx - 1]!.features.filter((f) => f.included).map((f) => f.key)
+    );
+    const newOnly = includedNow.filter((f) => !prevIncluded.has(f.key));
+    return { items: newOnly, prevPlanName: plans[idx - 1]!.name };
+  });
+
   return (
     <section id="pricing" className="py-16 sm:py-20">
       <div className="mx-auto max-w-7xl px-6 lg:px-10">
-        <div className="flex flex-col gap-10">
-          <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="flex flex-col gap-8">
+          {/* Heading + billing toggle */}
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-3xl">
-              <Heading className="font-display text-3xl/[1.08] font-medium tracking-[-0.03em] text-mist-950 sm:text-4xl/[1.04]">
+              <Heading className="font-display text-3xl/[1.08] font-medium tracking-[-0.03em] text-mist-950 sm:text-4xl/[1.04] text-balance">
                 {t("title", {
                   defaultValue: "Pricing to fit your business needs.",
                 })}
               </Heading>
+              <p className="mt-4 text-lg text-mist-600 text-pretty">
+                {t("subtitle", {
+                  defaultValue:
+                    "Start free, scale when you ship. No per-seat fees, no enterprise contracts — just transparent pricing built for teams shipping globally.",
+                })}
+              </p>
             </div>
 
-            <div className="inline-flex w-fit items-center gap-2 rounded-full border border-mist-200 bg-white p-1.5 shadow-[0_18px_50px_-40px_rgba(15,23,42,0.35)]">
+            <div className="inline-flex w-fit items-center gap-1 rounded-full border border-mist-200 bg-white p-1">
               <button
                 type="button"
                 aria-pressed={billingPeriod === "monthly"}
                 onClick={() => setBillingPeriod("monthly")}
                 className={cn(
-                  "cursor-pointer rounded-full px-4 py-2 text-sm font-medium transition-all duration-200",
+                  "cursor-pointer rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors duration-200",
                   billingPeriod === "monthly"
                     ? "bg-mist-950 text-white"
-                    : "text-mist-700 hover:text-mist-950"
+                    : "text-mist-600 hover:text-mist-950"
                 )}
               >
                 {t("monthly", { defaultValue: "Monthly" })}
@@ -109,32 +118,34 @@ export default function Pricing({
                 aria-pressed={billingPeriod === "yearly"}
                 onClick={() => setBillingPeriod("yearly")}
                 className={cn(
-                  "cursor-pointer flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-all duration-200",
+                  "cursor-pointer flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors duration-200",
                   billingPeriod === "yearly"
                     ? "bg-mist-950 text-white"
-                    : "text-mist-700 hover:text-mist-950"
+                    : "text-mist-600 hover:text-mist-950"
                 )}
               >
                 {t("yearly", { defaultValue: "Yearly" })}
                 <span
                   className={cn(
-                    "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                    "rounded-full px-1.5 py-0.5 text-[10px] font-semibold tabular-nums",
                     billingPeriod === "yearly"
-                      ? "bg-emerald-500 text-white"
-                      : "bg-emerald-100 text-emerald-700"
+                      ? "bg-white/15 text-white"
+                      : "bg-mist-100 text-mist-700"
                   )}
                 >
-                  {t("save20", { defaultValue: "Save 20%" })}
+                  −20%
                 </span>
               </button>
             </div>
           </div>
 
-          <div className="grid auto-rows-fr grid-cols-1 gap-4 lg:grid-cols-3">
-            {plans.map((plan) => {
+          {/* Plans — framed grid block, title + toggle stay outside */}
+          <div className="grid grid-cols-1 gap-y-12 lg:grid-cols-3 lg:gap-y-0 lg:divide-x lg:divide-mist-200/70 rounded-3xl border border-mist-200/70 bg-white p-5 sm:p-6 lg:p-8 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+            {plans.map((plan, planIdx) => {
               const isPopular = plan.popular;
               const isEnterprise = plan.planId === "enterprise";
               const priceData = getDisplayPrice(plan, billingPeriod);
+              const featureRows = featureRowsByPlan[planIdx]!;
 
               // Display price: CMS-driven with locale currency
               const displayPrice = isEnterprise
@@ -159,96 +170,55 @@ export default function Pricing({
               return (
                 <div
                   key={plan.planId}
-                  className={cn(
-                    "flex h-full flex-col rounded-[1.75rem] border border-mist-200 bg-white p-5 shadow-[0_18px_50px_-40px_rgba(15,23,42,0.35)] sm:p-6",
-                    isPopular && "border-mist-950/20 shadow-[0_30px_90px_-60px_rgba(15,23,42,0.4)]"
-                  )}
+                  className="flex flex-col px-0 pb-0 lg:px-8 lg:first:pl-0 lg:last:pr-0"
                 >
-                  <div className="flex flex-1 flex-col">
-                    <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <h3 className="text-2xl font-medium tracking-[-0.02em] text-mist-950">
-                          {plan.name}
-                        </h3>
-                        <p className="mt-2 text-sm leading-6 text-mist-600">
-                          {plan.description}
-                        </p>
-                      </div>
-                      {isPopular ? (
-                        <span className="inline-flex shrink-0 rounded-full bg-mist-950 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-white">
-                          {t("mostPopular", { defaultValue: "Most popular" })}
+                  {/* Most-popular eyebrow — subtle, no pill */}
+                  {isPopular ? (
+                    <p className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-mist-950 mb-2">
+                      <span aria-hidden>★</span>
+                      {t("mostPopular", { defaultValue: "Most popular" })}
+                    </p>
+                  ) : (
+                    <p className="text-[10px] mb-2 select-none invisible" aria-hidden>
+                      placeholder
+                    </p>
+                  )}
+
+                  {/* Plan name */}
+                  <h3 className="text-xl font-semibold tracking-[-0.01em] text-mist-950">
+                    {plan.name}
+                  </h3>
+
+                  {/* Description */}
+                  <p className="mt-1.5 text-sm leading-relaxed text-mist-600 text-pretty">
+                    {plan.description}
+                  </p>
+
+                  {/* Price */}
+                  <div className="mt-6">
+                    <div className="flex items-baseline gap-1.5">
+                      <span className="text-3xl font-semibold tracking-[-0.03em] text-mist-950 tabular-nums">
+                        {displayPrice}
+                      </span>
+                      {!isEnterprise ? (
+                        <span className="text-sm text-mist-500">
+                          {t("perMonth", { defaultValue: "/mo" })}
                         </span>
                       ) : null}
                     </div>
-
-                    <div className="mt-5 border-b border-mist-100 pb-5">
-                      <div className="flex items-end gap-2">
-                        <span className="text-3xl font-semibold tracking-[-0.04em] text-mist-950">
-                          {displayPrice}
-                        </span>
-                        {!isEnterprise ? (
-                          <span className="pb-1 text-sm text-mist-600">
-                            {t("perMonth", { defaultValue: "/mo" })}
-                          </span>
-                        ) : null}
-                      </div>
-                      {billedYearlyNote ? (
-                        <p className="mt-2 text-xs font-medium text-mist-500">
-                          {billedYearlyNote}
-                        </p>
-                      ) : null}
-                    </div>
-
-                    <div className="mt-5">
-                      {/* Limits */}
-                      <div className="grid grid-cols-2 gap-x-5 gap-y-3">
-                        {plan.limits.map((limit) => (
-                          <div key={limit.key} className="space-y-1">
-                            <span className="block text-xs uppercase tracking-[0.12em] text-mist-500">
-                              {t(`labels.${limit.key}`, {
-                                defaultValue: limitLabelDefaults[limit.key] ?? limit.key,
-                              })}
-                            </span>
-                            <span className="block text-sm font-medium text-mist-950">
-                              {t(`limits.${limit.value}`, {
-                                defaultValue: limit.value,
-                              })}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-
-                      {/* Features */}
-                      <div className="mt-5 grid gap-x-5 gap-y-2.5 border-t border-mist-100 pt-5 sm:grid-cols-2">
-                        {plan.features.map((feature) => (
-                          <div
-                            key={feature.key}
-                            className="flex items-center justify-between gap-3 text-[13px]"
-                          >
-                            <span
-                              className={cn(
-                                "text-mist-700",
-                                !feature.included && "text-mist-400"
-                              )}
-                            >
-                              {t(`labels.${feature.key}`, {
-                                defaultValue: featureLabelDefaults[feature.key] ?? feature.key,
-                              })}
-                            </span>
-                            <FeatureIndicator enabled={feature.included} />
-                          </div>
-                        ))}
-                      </div>
-                    </div>
+                    <p className="mt-1 text-xs text-mist-500 min-h-[1rem]">
+                      {billedYearlyNote ?? (isEnterprise ? t("annualBillingOnly", { defaultValue: "Annual billing only" }) : " ")}
+                    </p>
                   </div>
 
+                  {/* CTA */}
                   <a
                     href={plan.ctaHref}
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label={`${plan.ctaLabel} — Better i18n ${plan.name}`}
                     className={cn(
-                      "mt-6 inline-flex items-center justify-center rounded-full px-4 py-3 text-sm font-medium transition-all duration-200",
+                      "mt-5 inline-flex w-full items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200",
                       isPopular
                         ? "bg-mist-950 text-white hover:bg-mist-800"
                         : "border border-mist-200 bg-white text-mist-950 hover:bg-mist-50"
@@ -256,6 +226,49 @@ export default function Pricing({
                   >
                     {plan.ctaLabel}
                   </a>
+
+                  {/* Limits — inline label · value */}
+                  <ul className="mt-8 space-y-2.5">
+                    {plan.limits.map((limit) => (
+                      <li
+                        key={limit.key}
+                        className="flex items-center justify-between gap-3 text-[13px]"
+                      >
+                        <span className="text-mist-600">
+                          {t(`labels.${limit.key}`, {
+                            defaultValue: limitLabelDefaults[limit.key] ?? limit.key,
+                          })}
+                        </span>
+                        <span className="text-mist-950 font-medium tabular-nums">
+                          {t(`limits.${limit.value}`, {
+                            defaultValue: limit.value,
+                          })}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  {/* Features — diff-only, rendered as one prose line per column instead of a list. */}
+                  {featureRows.items.length > 0 ? (
+                    <p className="mt-6 text-[13px] leading-relaxed text-mist-600 text-pretty">
+                      {featureRows.prevPlanName ? (
+                        <span className="text-mist-500">
+                          {t("everythingInPlus", {
+                            plan: featureRows.prevPlanName,
+                            defaultValue: `Everything in ${featureRows.prevPlanName}, plus:`,
+                          })}{" "}
+                        </span>
+                      ) : null}
+                      {featureRows.items
+                        .map((feature) =>
+                          t(`labels.${feature.key}`, {
+                            defaultValue:
+                              featureLabelDefaults[feature.key] ?? feature.key,
+                          })
+                        )
+                        .join(" · ")}
+                    </p>
+                  ) : null}
                 </div>
               );
             })}

--- a/apps/landing/src/components/PricingComparison.tsx
+++ b/apps/landing/src/components/PricingComparison.tsx
@@ -1,107 +1,667 @@
 import { useT } from "@/lib/i18n";
+import { SpriteIcon } from "@/components/SpriteIcon";
 
-const COMPETITORS = [
-  { name: "Better i18n", price: "$79/mo", highlight: true },
-  { name: "Lokalise", price: "$290\u2013585/mo" },
-  { name: "Crowdin", price: "$400/mo" },
-  { name: "Phrase", price: "$2,100/mo" },
-] as const;
+// ─── Types ───────────────────────────────────────────────────────────
 
-function getDifference(competitorPrice: string, lessLabel: string): string {
-  const betterI18nPrice = 79;
-  const match = competitorPrice.match(/\$(\d[\d,]*)/);
-  if (!match) return "\u2014";
-  const lowest = parseInt(match[1].replace(",", ""), 10);
-  const pct = Math.round(((lowest - betterI18nPrice) / lowest) * 100);
-  return lessLabel.replace("{pct}", String(pct));
+const VENDORS = ["betterI18n", "lokalise", "crowdin", "phrase"] as const;
+type Vendor = (typeof VENDORS)[number];
+
+/**
+ * Cell semantics:
+ *   true            → ✓ (full support)
+ *   false           → — (not available)
+ *   string          → literal text, NOT translated (e.g. prices "$290 / mo", counts "8+")
+ *   { i18n, fb }    → translated cell value via `comparison.values.{i18n}` key
+ */
+type Cell = true | false | string | { i18n: string; fb: string };
+
+const VENDOR_LABELS: Record<Vendor, string> = {
+  betterI18n: "Better i18n",
+  lokalise: "Lokalise",
+  crowdin: "Crowdin",
+  phrase: "Phrase",
+};
+
+/**
+ * Render the vendor label. Better i18n is special-cased to show our logo
+ * + branded wordmark; competitors render as plain text.
+ */
+function VendorHeader({ vendor }: { vendor: Vendor }) {
+  if (vendor === "betterI18n") {
+    return (
+      <span className="inline-flex items-center justify-center gap-2">
+        <img
+          src="/brand/logo.svg"
+          alt=""
+          aria-hidden
+          className="size-5 shrink-0"
+          loading="lazy"
+        />
+        <span>Better I18N</span>
+      </span>
+    );
+  }
+  return <span>{VENDOR_LABELS[vendor]}</span>;
 }
+
+type Item =
+  | { type: "section"; key: string; fb: string }
+  | {
+      type: "row";
+      key: string;
+      fb: string;
+      cells: Record<Vendor, Cell>;
+    };
+
+// ─── Cell value shorthands ───────────────────────────────────────────
+
+const v = (i18n: string, fb: string) => ({ i18n, fb });
+
+const VAL = {
+  unlimited: v("unlimited", "Unlimited"),
+  limited: v("limited", "Limited"),
+  payPerWord: v("payPerWord", "Pay per word"),
+  addOn: v("addOn", "Add-on"),
+  builtIn: v("builtIn", "Built-in"),
+  plugin: v("plugin", "Plugin"),
+  native: v("native", "Native"),
+  custom: v("custom", "Custom"),
+  trialOnly: v("trialOnly", "Trial only"),
+  few: v("few", "Few"),
+};
+
+// ─── Comparison matrix (the source of truth) ─────────────────────────
+
+const ITEMS: Item[] = [
+  // ── Pricing ────────────────────────────────────────────────────────
+  { type: "section", key: "sections.pricing", fb: "Pricing" },
+  {
+    type: "row",
+    key: "rows.startingPrice",
+    fb: "Starting price",
+    cells: {
+      betterI18n: v("free", "Free"),
+      lokalise: "$290 / mo",
+      crowdin: "$400 / mo",
+      phrase: "$2,100 / mo",
+    },
+  },
+  {
+    type: "row",
+    key: "rows.proPrice",
+    fb: "Pro tier",
+    cells: {
+      betterI18n: "$20 / mo",
+      lokalise: "$290 / mo",
+      crowdin: "$400 / mo",
+      phrase: "$2,100 / mo",
+    },
+  },
+  {
+    type: "row",
+    key: "rows.freeTier",
+    fb: "Free forever tier",
+    cells: {
+      betterI18n: true,
+      lokalise: VAL.trialOnly,
+      crowdin: VAL.limited,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.perSeat",
+    fb: "Per-seat pricing",
+    cells: {
+      betterI18n: false,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.annualLockIn",
+    fb: "Annual contract required",
+    cells: {
+      betterI18n: false,
+      lokalise: false,
+      crowdin: false,
+      phrase: true,
+    },
+  },
+
+  // ── Translation engine ─────────────────────────────────────────────
+  { type: "section", key: "sections.engine", fb: "Translation engine" },
+  {
+    type: "row",
+    key: "rows.aiTranslations",
+    fb: "AI translations included",
+    cells: {
+      betterI18n: VAL.unlimited,
+      lokalise: VAL.payPerWord,
+      crowdin: VAL.limited,
+      phrase: VAL.addOn,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.translationMemory",
+    fb: "Translation memory",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.glossary",
+    fb: "Glossary management",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.brandVoice",
+    fb: "Brand voice tuning",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.ragContext",
+    fb: "RAG context retrieval",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.aiSuggestions",
+    fb: "Inline AI suggestions",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+
+  // ── Developer experience ───────────────────────────────────────────
+  { type: "section", key: "sections.devEx", fb: "Developer experience" },
+  {
+    type: "row",
+    key: "rows.gitSync",
+    fb: "Git sync",
+    cells: {
+      betterI18n: VAL.builtIn,
+      lokalise: VAL.plugin,
+      crowdin: VAL.plugin,
+      phrase: VAL.plugin,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.cli",
+    fb: "CLI tool",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.typeSafeSdk",
+    fb: "Type-safe SDK",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.openSourceSdks",
+    fb: "Open-source SDKs",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.mcpServer",
+    fb: "MCP server for AI agents",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.frameworkSupport",
+    fb: "Framework adapters",
+    cells: {
+      betterI18n: "8+",
+      lokalise: VAL.few,
+      crowdin: VAL.few,
+      phrase: VAL.few,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.webhooks",
+    fb: "Webhook events",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+
+  // ── Content delivery ───────────────────────────────────────────────
+  { type: "section", key: "sections.delivery", fb: "Content delivery" },
+  {
+    type: "row",
+    key: "rows.edgeCdn",
+    fb: "Edge CDN delivery",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.cachePurge",
+    fb: "Instant cache purge on publish",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.namespaces",
+    fb: "Per-namespace JSON delivery",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.staticFallback",
+    fb: "Static fallback bundles",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.versioning",
+    fb: "Translation versioning",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+
+  // ── Content & marketing ─────────────────────────────────────────────
+  { type: "section", key: "sections.content", fb: "Content & marketing" },
+  {
+    type: "row",
+    key: "rows.contentCms",
+    fb: "Headless CMS bundled",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.marketingPages",
+    fb: "Localized marketing pages",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.blog",
+    fb: "Multilingual blog",
+    cells: {
+      betterI18n: true,
+      lokalise: false,
+      crowdin: false,
+      phrase: false,
+    },
+  },
+
+  // ── Workflow & QA ───────────────────────────────────────────────────
+  { type: "section", key: "sections.workflow", fb: "Workflow & QA" },
+  {
+    type: "row",
+    key: "rows.reviewWorkflow",
+    fb: "Review workflow",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.comments",
+    fb: "Comments on translations",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.qaChecks",
+    fb: "Automated QA checks",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.branching",
+    fb: "Branching workflow",
+    cells: {
+      betterI18n: true,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+
+  // ── Enterprise ──────────────────────────────────────────────────────
+  { type: "section", key: "sections.enterprise", fb: "Enterprise" },
+  {
+    type: "row",
+    key: "rows.sso",
+    fb: "SSO / SAML",
+    cells: {
+      betterI18n: VAL.custom,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.auditLog",
+    fb: "Audit log",
+    cells: {
+      betterI18n: VAL.custom,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.sla",
+    fb: "SLA guarantee",
+    cells: {
+      betterI18n: VAL.custom,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.dedicatedSupport",
+    fb: "Dedicated account manager",
+    cells: {
+      betterI18n: VAL.custom,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+  {
+    type: "row",
+    key: "rows.dataResidency",
+    fb: "Custom data residency",
+    cells: {
+      betterI18n: VAL.custom,
+      lokalise: true,
+      crowdin: true,
+      phrase: true,
+    },
+  },
+];
+
+// ─── Cell renderer ───────────────────────────────────────────────────
+
+function CellValue({
+  value,
+  highlight,
+  t,
+}: {
+  value: Cell;
+  highlight: boolean;
+  t: ReturnType<typeof useT>;
+}) {
+  if (value === true) {
+    return (
+      <span
+        aria-label="Included"
+        className={
+          highlight
+            ? "inline-flex size-4 items-center justify-center rounded-full bg-mist-950 text-white"
+            : "inline-flex size-4 items-center justify-center text-mist-500"
+        }
+      >
+        <SpriteIcon name="checkmark" className="size-2.5" />
+      </span>
+    );
+  }
+  if (value === false) {
+    return (
+      <span aria-label="Not available" className="text-mist-300 text-sm">
+        —
+      </span>
+    );
+  }
+  if (typeof value === "string") {
+    return (
+      <span
+        className={
+          highlight
+            ? "text-[13px] font-medium text-mist-950 tabular-nums"
+            : "text-[13px] text-mist-600 tabular-nums"
+        }
+      >
+        {value}
+      </span>
+    );
+  }
+  // Translated value
+  return (
+    <span
+      className={
+        highlight
+          ? "text-[13px] font-medium text-mist-950"
+          : "text-[13px] text-mist-600"
+      }
+    >
+      {t(`comparison.values.${value.i18n}`, { defaultValue: value.fb })}
+    </span>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────────────
 
 export function PricingComparison() {
   const t = useT("pricing");
 
   return (
-    <section id="compare-pricing" className="py-16 bg-white">
-      <div className="mx-auto max-w-4xl px-6 lg:px-10">
-        <h2 className="font-display text-2xl font-medium text-mist-950 mb-8 text-center">
-          {t("comparison.title", {
-            defaultValue: "How Better i18n compares on price",
-          })}
-        </h2>
-
-        <div className="overflow-hidden rounded-2xl border border-mist-200 bg-white">
-          {/* Header */}
-          <div
-            role="row"
-            className="grid grid-cols-3 bg-mist-50 border-b border-mist-200"
-          >
-            <div
-              role="columnheader"
-              className="p-4 text-sm font-medium text-mist-600"
-            >
-              {t("comparison.competitor", { defaultValue: "Competitor" })}
-            </div>
-            <div
-              role="columnheader"
-              className="p-4 text-sm font-medium text-mist-600 text-center border-l border-mist-200"
-            >
-              {t("comparison.teamCost", { defaultValue: "10-Person Team Cost" })}
-            </div>
-            <div
-              role="columnheader"
-              className="p-4 text-sm font-medium text-mist-600 text-center border-l border-mist-200"
-            >
-              {t("comparison.difference", { defaultValue: "Difference" })}
-            </div>
-          </div>
-
-          {/* Rows */}
-          {COMPETITORS.map((competitor) => {
-            const isHighlight = "highlight" in competitor && competitor.highlight;
-            const lessLabel = t("comparison.less", { defaultValue: "{pct}% less" });
-            const difference = isHighlight
-              ? "\u2014"
-              : getDifference(competitor.price, lessLabel);
-
-            return (
-              <div
-                key={competitor.name}
-                role="row"
-                className={`grid grid-cols-3 border-b border-mist-100 last:border-b-0 ${
-                  isHighlight
-                    ? "bg-emerald-50 border-emerald-200"
-                    : ""
-                }`}
-              >
-                <div role="cell" className="p-4 text-sm text-mist-700">
-                  <span className={isHighlight ? "font-medium text-mist-950" : ""}>
-                    {competitor.name}
-                  </span>
-                </div>
-                <div
-                  role="cell"
-                  className="p-4 text-sm text-center border-l border-mist-100"
-                >
-                  <span className={isHighlight ? "font-medium text-mist-950" : "text-mist-700"}>
-                    {competitor.price}
-                  </span>
-                </div>
-                <div
-                  role="cell"
-                  className="p-4 text-sm text-center border-l border-mist-100"
-                >
-                  <span className={isHighlight ? "font-medium text-emerald-700" : "text-emerald-600"}>
-                    {difference}
-                  </span>
-                </div>
-              </div>
-            );
-          })}
+    <section id="compare-pricing" className="py-20 sm:py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-10">
+        {/* Header — left-aligned, mirrors Pricing block */}
+        <div className="max-w-3xl mb-12">
+          <h2 className="font-display text-3xl/[1.08] font-medium tracking-[-0.03em] text-mist-950 sm:text-4xl/[1.04] text-balance">
+            {t("comparison.title", {
+              defaultValue: "Why teams choose Better i18n over legacy TMS",
+            })}
+          </h2>
+          <p className="mt-5 text-lg text-mist-600 text-pretty">
+            {t("comparison.subtitle", {
+              defaultValue:
+                "Better i18n delivers the same translation memory and review workflows — with native AI, edge CDN delivery, and a modern stack — without the enterprise contract.",
+            })}
+          </p>
         </div>
 
-        <p className="mt-4 text-xs text-mist-500 text-center">
+        {/* Comparison table — framed, mirrors Pricing block aesthetic */}
+        <div className="rounded-3xl border border-mist-200/70 bg-white p-1.5 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[720px] border-collapse">
+              {/* Vendor header row */}
+              <thead className="bg-white">
+                <tr>
+                  <th className="text-left text-xs font-medium uppercase tracking-wider text-mist-500 px-5 py-4 w-[40%]">
+                    {t("comparison.featureLabel", { defaultValue: "Feature" })}
+                  </th>
+                  {VENDORS.map((vendor) => {
+                    const highlight = vendor === "betterI18n";
+                    return (
+                      <th
+                        key={vendor}
+                        scope="col"
+                        className={
+                          highlight
+                            ? "text-center text-sm font-semibold text-mist-950 px-4 py-4 bg-mist-50/60 rounded-t-xl"
+                            : "text-center text-sm font-medium text-mist-700 px-4 py-4"
+                        }
+                      >
+                        <VendorHeader vendor={vendor} />
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+
+              {/* Body — interleaves section labels and feature rows */}
+              <tbody>
+                {ITEMS.map((item, idx) => {
+                  if (item.type === "section") {
+                    return (
+                      <tr
+                        key={`section-${item.key}-${idx}`}
+                        className="border-t border-mist-200/70"
+                      >
+                        <td
+                          colSpan={1}
+                          className="px-5 pt-6 pb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-mist-500"
+                        >
+                          {t(`comparison.${item.key}`, {
+                            defaultValue: item.fb,
+                          })}
+                        </td>
+                        {/* Highlight column continues even on section rows */}
+                        <td className="bg-mist-50/60" colSpan={1} />
+                        <td colSpan={2} />
+                      </tr>
+                    );
+                  }
+
+                  // Feature row
+                  // Detect whether this is the LAST feature row of the
+                  // entire matrix to round Better i18n column's bottom corners.
+                  const isLastRow = idx === ITEMS.length - 1;
+
+                  return (
+                    <tr key={item.key} className="border-t border-mist-100">
+                      <th
+                        scope="row"
+                        className="text-left text-[13px] font-normal text-mist-700 px-5 py-3"
+                      >
+                        {t(`comparison.${item.key}`, {
+                          defaultValue: item.fb,
+                        })}
+                      </th>
+                      {VENDORS.map((vendor) => {
+                        const highlight = vendor === "betterI18n";
+                        return (
+                          <td
+                            key={vendor}
+                            className={
+                              highlight
+                                ? `text-center px-4 py-3.5 bg-mist-50/60 ${isLastRow ? "rounded-b-xl" : ""}`
+                                : "text-center px-4 py-3.5"
+                            }
+                          >
+                            <CellValue
+                              value={item.cells[vendor]}
+                              highlight={highlight}
+                              t={t}
+                            />
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Disclaimer */}
+        <p className="mt-5 text-xs text-mist-500 text-center">
           {t("comparison.disclaimer", {
             defaultValue:
-              "Based on publicly available pricing as of March 2026",
+              "Based on publicly available pricing and feature documentation as of 2026.",
           })}
         </p>
       </div>

--- a/apps/landing/src/components/UserSegments.tsx
+++ b/apps/landing/src/components/UserSegments.tsx
@@ -2,36 +2,198 @@ import { Link, useParams } from "@tanstack/react-router";
 import { useT } from "@/lib/i18n";
 import { SpriteIcon, type SpriteIconName } from "@/components/SpriteIcon";
 
+import { FlagIcon } from "./features/FlagIcon";
+
+type Tone = "translators" | "developers" | "productTeams";
+
+const TONES: Record<
+  Tone,
+  {
+    iconBg: string;
+    iconBorder: string;
+    iconText: string;
+    panelBg: string;
+    checkText: string;
+  }
+> = {
+  translators: {
+    iconBg: "bg-sky-50",
+    iconBorder: "border-sky-100",
+    iconText: "text-sky-700",
+    panelBg: "bg-gradient-to-br from-sky-50/40 via-white to-mist-50/60",
+    checkText: "text-sky-600",
+  },
+  developers: {
+    iconBg: "bg-indigo-50",
+    iconBorder: "border-indigo-100",
+    iconText: "text-indigo-700",
+    panelBg: "bg-gradient-to-br from-indigo-50/40 via-white to-mist-50/60",
+    checkText: "text-indigo-600",
+  },
+  productTeams: {
+    iconBg: "bg-amber-50",
+    iconBorder: "border-amber-100",
+    iconText: "text-amber-700",
+    panelBg: "bg-gradient-to-br from-amber-50/40 via-white to-mist-50/60",
+    checkText: "text-amber-600",
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/* Mini previews — one per persona, decorative product hints.          */
+/* Live inside the framed panel, beneath the description.              */
+/* ------------------------------------------------------------------ */
+
+function TranslatorsPreview() {
+  return (
+    <div className="rounded-lg border border-mist-200/80 bg-white/80 backdrop-blur-sm overflow-hidden shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+      {/* Glossary entry header */}
+      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-mist-100">
+        <span aria-hidden className="size-1.5 rounded-full bg-mist-400" />
+        <code className="text-[10px] font-mono text-mist-700">api.key</code>
+        <span className="ml-auto text-[8px] uppercase tracking-wider text-mist-400">
+          Glossary
+        </span>
+      </div>
+      {/* 3 language rows — source · approved · AI-suggested */}
+      <div className="px-3 py-2 space-y-1.5">
+        <div className="flex items-center gap-2">
+          <FlagIcon countryCode="gb" className="w-3 h-2" />
+          <span className="text-[10px] text-mist-500 italic">API Key</span>
+          <span className="ml-auto text-[9px] text-mist-400">source</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <FlagIcon countryCode="tr" className="w-3 h-2" />
+          <span className="text-[11px] text-mist-900">API Anahtarı</span>
+          <span className="ml-auto text-[9px] text-mist-500">approved</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <FlagIcon countryCode="de" className="w-3 h-2" />
+          <span className="text-[11px] text-mist-900">API-Schlüssel</span>
+          <span className="ml-auto text-[9px] text-mist-500 italic">AI</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DevelopersPreview() {
+  return (
+    <div className="rounded-lg border border-mist-200/80 bg-mist-100/70 overflow-hidden shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+      {/* Terminal chrome — traffic lights */}
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-mist-200/70">
+        <span aria-hidden className="size-1.5 rounded-full bg-rose-300/80" />
+        <span aria-hidden className="size-1.5 rounded-full bg-amber-300/80" />
+        <span aria-hidden className="size-1.5 rounded-full bg-emerald-300/80" />
+        <span className="ml-auto text-[9px] font-mono text-mist-400">
+          claude · mcp
+        </span>
+      </div>
+      {/* Terminal body */}
+      <pre className="px-3 py-2 text-[10px] font-mono leading-[1.6] text-mist-700 whitespace-pre">
+        <span className="text-emerald-600">$</span>{" "}
+        <span className="text-indigo-700">claude mcp</span>{" "}
+        <span className="text-mist-700">better-i18n</span>
+        {"\n"}
+        <span className="text-mist-400">  ▸ </span>
+        <span className="text-amber-700">proposeTranslations</span>
+        <span className="text-mist-400">(</span>
+        <span className="text-emerald-700">"auth.login"</span>
+        <span className="text-mist-400">)</span>
+        {"\n"}
+        <span className="text-emerald-600">✓</span>{" "}
+        <span className="text-mist-500">3 translations · 240ms</span>
+      </pre>
+    </div>
+  );
+}
+
+function ProductTeamsPreview() {
+  // Color thresholds match the platform's coverage convention:
+  //   ≥90 emerald (shipped)  ·  50–89 amber (in progress)  ·  <50 red (gap)
+  const ROWS = [
+    { country: "de", pct: 100 },
+    { country: "fr", pct: 73 },
+    { country: "tr", pct: 28 },
+  ];
+  const barColor = (pct: number) =>
+    pct >= 90
+      ? "bg-emerald-500"
+      : pct >= 50
+        ? "bg-amber-400"
+        : "bg-rose-400";
+  const textColor = (pct: number) =>
+    pct >= 90
+      ? "text-emerald-700"
+      : pct >= 50
+        ? "text-amber-700"
+        : "text-rose-600";
+  return (
+    <div className="rounded-lg border border-mist-200/80 bg-white/80 backdrop-blur-sm overflow-hidden shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+      {/* Header chrome — mirrors Translators panel for visual parity */}
+      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-mist-100">
+        <span aria-hidden className="size-1.5 rounded-full bg-emerald-400" />
+        <code className="text-[10px] font-mono text-mist-700">coverage</code>
+        <span className="ml-auto text-[8px] uppercase tracking-wider text-mist-400">
+          Live
+        </span>
+      </div>
+      {/* Body — 3 progress rows, matches Translators body padding */}
+      <div className="px-3 py-2 space-y-1.5">
+        {ROWS.map((row) => (
+          <div key={row.country} className="flex items-center gap-2">
+            <FlagIcon countryCode={row.country} className="w-3.5 h-2.5" />
+            <div className="flex-1 h-1 rounded-full bg-mist-100 overflow-hidden">
+              <div
+                className={`h-full ${barColor(row.pct)} rounded-full`}
+                style={{ width: `${row.pct}%` }}
+              />
+            </div>
+            <span
+              className={`text-[9px] font-mono tabular-nums w-7 text-right font-semibold ${textColor(row.pct)}`}
+            >
+              {row.pct}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Card                                                                */
+/* ------------------------------------------------------------------ */
+
 type SegmentCardProps = {
-  accentClassName: string;
-  accentBarClassName: string;
-  accentCheckClassName: string;
   iconName: SpriteIconName;
   id: string;
   namespace: string;
+  tone: Tone;
+  preview: React.ReactNode;
   to:
-    | "/$locale/for-developers"
-    | "/$locale/for-product-teams"
-    | "/$locale/for-translators";
+    | "/$locale/for-developers/"
+    | "/$locale/for-product-teams/"
+    | "/$locale/for-translators/";
   locale: string;
 };
 
 function SegmentCard({
-  accentClassName,
-  accentBarClassName,
-  accentCheckClassName,
   iconName,
   id,
   locale,
   namespace,
+  tone,
+  preview,
   to,
 }: SegmentCardProps) {
   const t = useT(namespace);
+  const palette = TONES[tone];
 
   const features = [
-    t("feature1Title", { defaultValue: "Feature One" }),
-    t("feature2Title", { defaultValue: "Feature Two" }),
-    t("feature3Title", { defaultValue: "Feature Three" }),
+    t("feature1Title"),
+    t("feature2Title"),
+    t("feature3Title"),
   ];
 
   return (
@@ -39,56 +201,60 @@ function SegmentCard({
       id={id}
       to={to}
       params={{ locale }}
-      className="group flex h-full scroll-mt-24 flex-col rounded-2xl border border-mist-200 bg-white shadow-[0_18px_50px_-40px_rgba(15,23,42,0.28)] transition-all duration-200 hover:-translate-y-0.5 hover:border-mist-300 hover:shadow-md overflow-hidden"
+      className="group flex h-full scroll-mt-24 flex-col rounded-2xl border border-mist-200 bg-white shadow-[0_18px_50px_-40px_rgba(15,23,42,0.28)] transition-shadow duration-200 hover:border-mist-300 hover:shadow-md overflow-hidden"
     >
-      {/* Colored top accent bar */}
-      <div className={`h-1 w-full ${accentBarClassName}`} />
-
-      <div className="flex flex-1 flex-col p-6">
-        {/* Header row */}
-        <div className="flex items-start justify-between gap-4">
-          <div
-            className={`flex size-11 shrink-0 items-center justify-center rounded-xl border border-white/80 bg-white shadow-sm ${accentClassName}`}
-          >
-            <SpriteIcon name={iconName} className="size-5" />
+      {/* Inner framed panel — content-sized; outer card aligns via grid + mt-auto on list */}
+      <div className="p-1.5">
+        <div
+          className={`rounded-xl border border-mist-200/60 ${palette.panelBg} px-5 pt-5 pb-5 flex flex-col`}
+        >
+          {/* Header row — icon + arrow */}
+          <div className="flex items-start justify-between gap-4 mb-4">
+            <div
+              className={`flex size-10 shrink-0 items-center justify-center rounded-xl border ${palette.iconBorder} ${palette.iconBg} ${palette.iconText} shadow-[0_1px_2px_rgba(15,23,42,0.04)]`}
+            >
+              <SpriteIcon name={iconName} className="size-4.5" />
+            </div>
+            <div className="rounded-full border border-mist-200 bg-white p-1.5 text-mist-400 transition-colors group-hover:text-mist-700">
+              <SpriteIcon
+                name="arrow-right"
+                className="size-3.5 transition-transform group-hover:translate-x-0.5"
+              />
+            </div>
           </div>
-          <div className="mt-0.5 rounded-full border border-mist-200 bg-white p-2 text-mist-400 transition-colors group-hover:text-mist-700">
-            <SpriteIcon
-              name="arrow-right"
-              className="size-4 transition-transform group-hover:translate-x-0.5"
-            />
+
+          {/* Eyebrow + title + description — min-h reserves uniform space across 2- and 3-line variants */}
+          <div>
+            <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-mist-500">
+              {t("statusBadge")}
+            </p>
+            <h3 className="mt-2 text-sm font-semibold text-mist-950">
+              {t("title")}
+            </h3>
+            <p className="mt-1.5 text-sm leading-relaxed text-mist-600 text-pretty min-h-[4.125rem]">
+              {t("description")}
+            </p>
+          </div>
+
+          {/* Mini preview — min-h reserves uniform vertical space; previews sit naturally at top */}
+          <div className="mt-4 min-h-[6rem] [&>div]:w-full">
+            {preview}
           </div>
         </div>
-
-        {/* Title block */}
-        <div className="mt-5">
-          <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-mist-500">
-            {t("statusBadge", { defaultValue: "Team Workflow" })}
-          </p>
-          <h3 className="mt-1.5 text-xl font-semibold text-mist-950">
-            {t("title", { defaultValue: "For Teams" })}
-          </h3>
-          <p className="mt-3 text-sm leading-6 text-mist-600">
-            {t("description", {
-              defaultValue: "Built to support your localization workflow.",
-            })}
-          </p>
-        </div>
-
-        {/* Feature list */}
-        <ul className="mt-5 space-y-2.5 border-t border-mist-100 pt-5">
-          {features.map((feature) => (
-            <li key={feature} className="flex items-center gap-2.5">
-              <div
-                className={`flex size-4 shrink-0 items-center justify-center rounded-full ${accentCheckClassName}`}
-              >
-                <SpriteIcon name="checkmark" className="size-2.5" />
-              </div>
-              <span className="text-sm text-mist-700">{feature}</span>
-            </li>
-          ))}
-        </ul>
       </div>
+
+      {/* Feature list — mt-auto pins it to card bottom across all 3 cards */}
+      <ul className="mt-auto px-6 pt-3 pb-5 space-y-2">
+        {features.map((feature) => (
+          <li key={feature} className="flex items-center gap-2.5">
+            <SpriteIcon
+              name="checkmark"
+              className="size-3 shrink-0 text-mist-400"
+            />
+            <span className="text-sm text-mist-700">{feature}</span>
+          </li>
+        ))}
+      </ul>
     </Link>
   );
 }
@@ -103,16 +269,11 @@ export default function UserSegments() {
       <div className="mx-auto max-w-7xl px-6 lg:px-10">
         <div className="space-y-12">
           <div className="max-w-2xl">
-            <h2 className="font-display text-3xl/[1.08] font-medium tracking-[-0.03em] text-mist-950 sm:text-4xl/[1.04]">
-              {t("title", {
-                defaultValue: "Built for Every Team",
-              })}
+            <h2 className="font-display text-3xl/[1.08] font-medium tracking-[-0.03em] text-mist-950 sm:text-4xl/[1.04] text-balance">
+              {t("title")}
             </h2>
-            <p className="mt-4 text-lg text-mist-600">
-              {t("subtitle", {
-                defaultValue:
-                  "Whether you're translating, building, or managing - Better i18n adapts to your workflow.",
-              })}
+            <p className="mt-4 text-lg text-mist-600 text-pretty">
+              {t("subtitle")}
             </p>
           </div>
 
@@ -121,30 +282,27 @@ export default function UserSegments() {
               id="for-translators"
               namespace="segments.translators"
               iconName="globe"
-              accentClassName="text-sky-700"
-              accentBarClassName="bg-sky-500"
-              accentCheckClassName="bg-sky-100 text-sky-600"
-              to="/$locale/for-translators"
+              tone="translators"
+              preview={<TranslatorsPreview />}
+              to="/$locale/for-translators/"
               locale={currentLocale}
             />
             <SegmentCard
               id="for-developers"
               namespace="segments.developers"
               iconName="code"
-              accentClassName="text-indigo-700"
-              accentBarClassName="bg-indigo-500"
-              accentCheckClassName="bg-indigo-100 text-indigo-600"
-              to="/$locale/for-developers"
+              tone="developers"
+              preview={<DevelopersPreview />}
+              to="/$locale/for-developers/"
               locale={currentLocale}
             />
             <SegmentCard
               id="for-product-teams"
               namespace="segments.productTeams"
               iconName="group"
-              accentClassName="text-amber-700"
-              accentBarClassName="bg-amber-500"
-              accentCheckClassName="bg-amber-100 text-amber-700"
-              to="/$locale/for-product-teams"
+              tone="productTeams"
+              preview={<ProductTeamsPreview />}
+              to="/$locale/for-product-teams/"
               locale={currentLocale}
             />
           </div>

--- a/apps/landing/src/components/features/AIFeatureCard.tsx
+++ b/apps/landing/src/components/features/AIFeatureCard.tsx
@@ -1,0 +1,266 @@
+/**
+ * AIFeatureCard — mirrors the real `proposeTranslations` tool-call card
+ * rendered inside the AI Drawer (`apps/app/components/translations/ai/`).
+ *
+ * Visual story: assistant identifies ONE key, shows the source value, then
+ * proposes target translations across N languages. Real flag images via
+ * `<FlagIcon />`, real Edit / Approve buttons via `@better-i18n/ui`.
+ *
+ * 5-beat story arc:
+ *   0 (1.0s): Thinking dots.
+ *   1 (1.0s): Tool pill + key header + source row reveal.
+ *   2 (0.9s): First target language streams in (DE).
+ *   3 (0.9s): Second target (FR).
+ *   4 (1.4s): Third target (TR) appears with shimmer (still streaming).
+ *   5 (2.2s): Shimmer clears, Approve glows — loop pause.
+ */
+
+import { useRef } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { Button } from "@better-i18n/ui/components/button";
+import { cn } from "@better-i18n/ui/lib/utils";
+
+import { useT } from "@/lib/i18n";
+import { DURATION, EASE_OUT } from "@/lib/motion";
+
+import { FlagIcon } from "./FlagIcon";
+import { useDemoLoop, type Beat } from "./use-demo-loop";
+
+const BEATS: ReadonlyArray<Beat> = [
+  { durationMs: 1000 },
+  { durationMs: 1000 },
+  { durationMs: 900 },
+  { durationMs: 900 },
+  { durationMs: 1400 },
+  { durationMs: 2200 },
+];
+
+type TargetRow = { country: string; code: string; value: string };
+
+const TARGETS: ReadonlyArray<TargetRow> = [
+  { country: "de", code: "DE", value: "Synchronisieren" },
+  { country: "fr", code: "FR", value: "Synchroniser" },
+  { country: "tr", code: "TR", value: "Eşitleme" },
+];
+
+export function AIFeatureCard() {
+  const t = useT("features.ai");
+  const ref = useRef<HTMLDivElement>(null);
+  const { beatIndex } = useDemoLoop({ beats: BEATS, ref });
+  const reduced = useReducedMotion();
+
+  const showShell = beatIndex >= 1;
+  const visibleTargets = Math.max(0, beatIndex - 1);
+  const isStreaming = beatIndex === 4;
+  const approved = beatIndex >= 5;
+
+  return (
+    <div
+      ref={ref}
+      className="flex flex-col h-full bg-white border border-mist-200 rounded-2xl overflow-hidden shadow-[0_18px_50px_-40px_rgba(15,23,42,0.35)] transition-shadow duration-200 hover:shadow-md"
+    >
+      <div className="p-1.5">
+        <div className="h-[320px] bg-mist-50 rounded-xl border border-mist-200/60 px-5 pt-6 pb-4 flex flex-col shrink-0 relative">
+          {/* Assistant header — Better i18n logo + model badge */}
+          <div className="flex items-center gap-2.5 mb-4">
+            <span
+              aria-hidden
+              className="size-6 rounded-md bg-white border border-mist-200 flex items-center justify-center shadow-[0_1px_2px_rgba(15,23,42,0.06)] overflow-hidden"
+            >
+              <img
+                src="/brand/logo.svg"
+                alt=""
+                className="size-3.5 object-contain"
+              />
+            </span>
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-[11px] font-semibold text-mist-900">
+                Better AI
+              </span>
+              <span className="text-[10px] text-mist-400 font-mono">
+                gemini-3-pro
+              </span>
+            </div>
+          </div>
+
+          {/* Tool-call shell */}
+          <div className="flex-1 bg-white rounded-xl border border-mist-200 shadow-sm overflow-hidden flex flex-col min-h-0">
+            {/* Tool header */}
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-mist-100">
+              <AnimatePresence mode="wait">
+                {showShell ? (
+                  <motion.div
+                    key="pill"
+                    initial={reduced ? false : { opacity: 0, y: -4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: DURATION.fast, ease: EASE_OUT }}
+                    className="flex items-center gap-1.5 w-full"
+                  >
+                    <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden />
+                    <code className="text-[10px] font-mono text-mist-900 font-semibold">
+                      proposeTranslations
+                    </code>
+                    <span className="text-[9px] text-mist-500 tabular-nums ml-auto">
+                      {visibleTargets}/{TARGETS.length}
+                    </span>
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="thinking"
+                    initial={reduced ? false : { opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: DURATION.fast }}
+                    className="flex items-center gap-1.5"
+                  >
+                    {[0, 1, 2].map((i) => (
+                      <motion.span
+                        key={i}
+                        className="size-1.5 rounded-full bg-mist-400"
+                        animate={
+                          reduced ? { opacity: 0.4 } : { opacity: [0.3, 1, 0.3] }
+                        }
+                        transition={{
+                          duration: 0.9,
+                          repeat: Infinity,
+                          ease: "easeInOut",
+                          delay: i * 0.15,
+                        }}
+                      />
+                    ))}
+                    <span className="text-[10px] text-mist-500 ml-1">
+                      {t("thinking")}
+                    </span>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+
+            {/* Key + source row */}
+            <motion.div
+              initial={reduced ? false : { opacity: 0, y: 4 }}
+              animate={{ opacity: showShell ? 1 : 0, y: showShell ? 0 : 4 }}
+              transition={{ duration: DURATION.base, ease: EASE_OUT }}
+              className="px-3 py-2 border-b border-mist-100 bg-mist-50/40"
+            >
+              <div className="flex items-center gap-1.5 mb-1">
+                <svg
+                  aria-hidden
+                  viewBox="0 0 16 16"
+                  className="size-3 text-mist-400"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                >
+                  <path d="M2 4l4-2 4 2 4-2v8l-4 2-4-2-4 2V4z" strokeLinejoin="round" />
+                  <path d="M6 2v8M10 4v8" />
+                </svg>
+                <code className="text-[11px] font-mono text-mist-900">
+                  dashboard.sync
+                </code>
+              </div>
+              <div className="flex items-center gap-2 pl-4.5 ml-px">
+                <FlagIcon countryCode="gb" />
+                <span className="text-[10px] text-mist-600 italic">
+                  Sync
+                </span>
+              </div>
+            </motion.div>
+
+            {/* Target language rows */}
+            <div className="flex-1 px-2 py-1.5 space-y-0.5 overflow-hidden min-h-0">
+              {TARGETS.map((row, i) => {
+                const visible = i < visibleTargets;
+                const streamingThisRow =
+                  isStreaming && i === TARGETS.length - 1;
+                return (
+                  <motion.div
+                    key={row.code}
+                    initial={reduced ? false : { opacity: 0, y: 4 }}
+                    animate={
+                      visible ? { opacity: 1, y: 0 } : { opacity: 0, y: 4 }
+                    }
+                    transition={{ duration: DURATION.base, ease: EASE_OUT }}
+                    className="flex items-center gap-2.5 px-2 py-1.5 rounded-md hover:bg-mist-50 relative overflow-hidden"
+                  >
+                    <FlagIcon countryCode={row.country} />
+                    <span className="text-[11px] text-mist-900 font-medium truncate flex-1">
+                      {row.value}
+                    </span>
+                    {streamingThisRow && !reduced && (
+                      <motion.div
+                        aria-hidden
+                        className="absolute inset-0 pointer-events-none"
+                        initial={{ x: "-100%" }}
+                        animate={{ x: "120%" }}
+                        transition={{
+                          duration: 1.4,
+                          ease: "easeInOut",
+                          repeat: Infinity,
+                        }}
+                        style={{
+                          background:
+                            "linear-gradient(90deg, transparent 0%, rgba(16,185,129,0.16) 50%, transparent 100%)",
+                        }}
+                      />
+                    )}
+                  </motion.div>
+                );
+              })}
+            </div>
+
+            {/* Footer actions */}
+            <div className="flex items-center justify-between gap-2 px-3 py-2 border-t border-mist-100">
+              <span className="text-[10px] text-mist-500">
+                {approved ? t("appliedHint") : t("reviewHint")}
+              </span>
+              <div className="flex items-center gap-1.5">
+                <Button
+                  variant="outline"
+                  size="xs"
+                  tabIndex={-1}
+                  className="h-6 px-2 text-[10px] text-mist-700 border-mist-200 bg-white hover:bg-mist-50"
+                >
+                  {t("edit")}
+                </Button>
+                <Button
+                  asChild
+                  size="xs"
+                  tabIndex={-1}
+                  className={cn(
+                    "h-6 px-2 text-[10px] font-semibold transition-[background-color]",
+                    approved
+                      ? "bg-emerald-600 text-white hover:bg-emerald-700"
+                      : "bg-mist-900 text-white hover:bg-mist-800",
+                  )}
+                >
+                  <motion.button
+                    type="button"
+                    animate={
+                      approved && !reduced
+                        ? { scale: [1, 1.04, 1] }
+                        : { scale: 1 }
+                    }
+                    transition={{ duration: 0.6, ease: EASE_OUT }}
+                  >
+                    {approved ? t("approved") : t("approve")}
+                  </motion.button>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Card footer — title + description */}
+      <div className="px-6 pt-2 pb-5 flex-1 flex flex-col">
+        <h3 className="text-sm font-semibold text-mist-950">
+          {t("title")}
+        </h3>
+        <p className="mt-1.5 text-sm text-mist-600 leading-relaxed text-pretty">
+          {t("description")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/src/components/features/FlagIcon.tsx
+++ b/apps/landing/src/components/features/FlagIcon.tsx
@@ -1,0 +1,32 @@
+/**
+ * FlagIcon — small inline country flag image used inside the feature
+ * cards. Same pattern that the AI drawer demo (`DemoAIDrawerStandalone`)
+ * uses, sourced from flagcdn.com.
+ *
+ * `countryCode` should be the ISO 3166-1 alpha-2 country code, NOT the
+ * BCP-47 language code. For locales whose language tag differs from the
+ * country code (e.g. `ja` → `jp`, `en` → `gb`/`us`), the caller is
+ * responsible for the mapping.
+ */
+
+import { cn } from "@better-i18n/ui/lib/utils";
+
+type FlagIconProps = {
+  countryCode: string;
+  className?: string;
+};
+
+export function FlagIcon({ countryCode, className }: FlagIconProps) {
+  return (
+    <img
+      src={`https://flagcdn.com/w40/${countryCode.toLowerCase()}.png`}
+      alt=""
+      aria-hidden
+      className={cn(
+        "w-4 h-3 rounded-[2px] object-cover shrink-0",
+        className,
+      )}
+      loading="lazy"
+    />
+  );
+}

--- a/apps/landing/src/components/features/McpFeatureCard.tsx
+++ b/apps/landing/src/components/features/McpFeatureCard.tsx
@@ -1,0 +1,198 @@
+/**
+ * McpFeatureCard — mirrors the real MCP `ConnectCard` from
+ * `apps/app/routes/(app)/$orgSlug/$projectSlug/integrations/mcp.tsx`.
+ *
+ * Visual reference: a tab strip across the top with IDE icons (Cursor,
+ * Claude Code, Windsurf, Antigravity), an underline indicator showing
+ * the active tab, and a code-block panel below with a filename header
+ * and a syntax-highlighted command/JSON payload.
+ *
+ * 4-beat story arc: cycles through the four IDEs, sliding the underline
+ * indicator and crossfading the code block content. Demonstrates that
+ * Better i18n's MCP works across every major coding agent.
+ */
+
+import { useRef } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import {
+  IconAntigravity,
+  IconClaudeai,
+  IconCursor,
+  IconWindsurf,
+} from "@central-icons-react/round-outlined-radius-2-stroke-2";
+
+import { useT } from "@/lib/i18n";
+import { DURATION, EASE_OUT } from "@/lib/motion";
+
+import { useDemoLoop, type Beat } from "./use-demo-loop";
+
+const BEATS: ReadonlyArray<Beat> = [
+  { durationMs: 2400 },
+  { durationMs: 2400 },
+  { durationMs: 2400 },
+  { durationMs: 2800 },
+];
+
+type TabSpec = {
+  id: string;
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  filename: string;
+  language: "json" | "bash" | "markdown";
+  code: string;
+};
+
+const TABS: ReadonlyArray<TabSpec> = [
+  {
+    id: "cursor",
+    label: "Cursor",
+    Icon: IconCursor,
+    filename: "~/.cursor/mcp.json",
+    language: "json",
+    code: `{
+  "mcpServers": {
+    "better-i18n": {
+      "command": "npx",
+      "args": ["-y", "@better-i18n/mcp"]
+    }
+  }
+}`,
+  },
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    Icon: IconClaudeai,
+    filename: "Terminal",
+    language: "bash",
+    code: `claude mcp add -s user \\
+  -e BETTER_I18N_API_KEY=*** \\
+  better-i18n -- npx @better-i18n/mcp`,
+  },
+  {
+    id: "windsurf",
+    label: "Windsurf",
+    Icon: IconWindsurf,
+    filename: "~/.codeium/windsurf/mcp_config.json",
+    language: "json",
+    code: `{
+  "mcpServers": {
+    "better-i18n": {
+      "command": "npx",
+      "args": ["-y", "@better-i18n/mcp"]
+    }
+  }
+}`,
+  },
+  {
+    id: "antigravity",
+    label: "Antigravity",
+    Icon: IconAntigravity,
+    filename: "GEMINI.md",
+    language: "markdown",
+    code: `# better-i18n MCP
+
+Use the better-i18n MCP server to manage
+translation keys and publish from chat.`,
+  },
+];
+
+export function McpFeatureCard() {
+  const t = useT("features.mcp");
+  const ref = useRef<HTMLDivElement>(null);
+  const { beatIndex } = useDemoLoop({ beats: BEATS, ref });
+  const reduced = useReducedMotion();
+
+  const active = TABS[beatIndex] ?? TABS[0];
+
+  return (
+    <div
+      ref={ref}
+      className="flex flex-col h-full bg-white border border-mist-200 rounded-2xl overflow-hidden shadow-[0_18px_50px_-40px_rgba(15,23,42,0.35)] transition-shadow duration-200 hover:shadow-md"
+    >
+      <div className="p-1.5">
+        <div className="h-[320px] bg-mist-50 rounded-xl border border-mist-200/60 px-5 pt-6 pb-4 flex flex-col shrink-0">
+        {/* Tab strip with sliding underline indicator */}
+        <div className="relative flex items-center gap-1 mb-3 border-b border-mist-200">
+          {TABS.map((tab, i) => {
+            const isActive = i === beatIndex;
+            return (
+              <div
+                key={tab.id}
+                className={`relative flex items-center gap-1.5 px-2 py-2 text-[10px] font-medium transition-colors ${
+                  isActive ? "text-mist-900" : "text-mist-500"
+                }`}
+              >
+                <tab.Icon className="size-3.5" />
+                <span>{tab.label}</span>
+                {isActive && (
+                  <motion.span
+                    layoutId="mcp-tab-indicator"
+                    className="absolute left-0 right-0 -bottom-px h-px bg-mist-900"
+                    transition={
+                      reduced
+                        ? { duration: 0 }
+                        : { duration: DURATION.base, ease: EASE_OUT }
+                    }
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Code block — filename header + content body */}
+        <div className="flex-1 bg-white rounded-xl border border-mist-200 shadow-sm overflow-hidden flex flex-col min-h-0">
+          <div className="flex items-center justify-between px-3 py-1.5 border-b border-mist-100">
+            <AnimatePresence mode="wait">
+              <motion.span
+                key={active.filename}
+                initial={reduced ? false : { opacity: 0, y: -2 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: DURATION.fast, ease: EASE_OUT }}
+                className="text-[10px] font-mono text-mist-500"
+              >
+                {active.filename}
+              </motion.span>
+            </AnimatePresence>
+            <span className="text-[9px] text-mist-400 uppercase tracking-wider">
+              {active.language}
+            </span>
+          </div>
+          <div className="flex-1 px-3 py-2.5 overflow-hidden">
+            <AnimatePresence mode="wait">
+              <motion.pre
+                key={active.id}
+                initial={reduced ? false : { opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: DURATION.base, ease: EASE_OUT }}
+                className="text-[10px] font-mono leading-[1.6] text-mist-700 whitespace-pre overflow-hidden"
+              >
+                {active.code}
+              </motion.pre>
+            </AnimatePresence>
+          </div>
+        </div>
+
+        {/* Bottom hint — works everywhere */}
+        <div className="flex items-center justify-center gap-1.5 mt-2">
+          <span aria-hidden className="size-1 rounded-full bg-emerald-500" />
+          <span className="text-[10px] text-mist-500">
+            {t("worksEverywhere")}
+          </span>
+        </div>
+        </div>
+      </div>
+
+      <div className="px-6 pt-2 pb-5 flex-1 flex flex-col">
+        <h3 className="text-sm font-semibold text-mist-950">
+          {t("title")}
+        </h3>
+        <p className="mt-1.5 text-sm text-mist-600 leading-relaxed text-pretty">
+          {t("description")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/src/components/features/PublishFeatureCard.tsx
+++ b/apps/landing/src/components/features/PublishFeatureCard.tsx
@@ -1,0 +1,258 @@
+/**
+ * PublishFeatureCard — mirrors the real publish status popover from
+ * `sync-status-button-group.tsx` (StatusSummaryCard + ActivityLog).
+ *
+ * The activity log walks through 7 sequential steps. Each step has three
+ * visual states:
+ *
+ *   - hidden    — not yet reached (faded)
+ *   - active    — currently running (blue, pulsing dot, no timestamp yet)
+ *   - completed — finished (emerald dot, timestamp revealed)
+ *
+ * The vertical connector line between dots fills with emerald (via scaleY)
+ * as each step completes — that progressive fill is what gives the card
+ * its "sync vibe": you can FEEL the work flowing top-to-bottom.
+ *
+ * Loop runs only while in viewport. Reduced-motion freezes at the end
+ * state.
+ */
+
+import { useRef } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+
+import { useT } from "@/lib/i18n";
+import { DURATION, EASE_OUT } from "@/lib/motion";
+
+import { FlagIcon } from "./FlagIcon";
+import { useDemoLoop, type Beat } from "./use-demo-loop";
+
+const STEPS = [
+  { key: "queued", label: "Queued", time: "14:32:00" },
+  { key: "filesGenerated", label: "Generating files", time: "14:32:01" },
+  { key: "uploadedToCdn", label: "Uploading to CDN", time: "14:32:04" },
+  { key: "manifestUploaded", label: "Manifest uploaded", time: "14:32:08" },
+  { key: "cachePurged", label: "CDN cache cleared", time: "14:32:11" },
+  { key: "prCreated", label: "Pull request created", time: "14:32:14" },
+  { key: "completed", label: "Completed", time: "14:32:16" },
+] as const;
+
+const BEATS: ReadonlyArray<Beat> = [
+  { durationMs: 1000 }, // 0 — Queued active
+  { durationMs: 700 },  // 1 — Generating files active
+  { durationMs: 700 },  // 2 — Uploading to CDN active
+  { durationMs: 700 },  // 3 — Manifest uploaded active
+  { durationMs: 700 },  // 4 — CDN cache cleared active
+  { durationMs: 700 },  // 5 — Pull request created active
+  { durationMs: 900 },  // 6 — Completed active
+  { durationMs: 2200 }, // 7 — all done, status emerald (pause)
+];
+
+const LANGUAGES = ["de", "fr", "jp"] as const;
+
+export function PublishFeatureCard() {
+  const t = useT("features.publish");
+  const ref = useRef<HTMLDivElement>(null);
+  const { beatIndex } = useDemoLoop({ beats: BEATS, ref });
+  const reduced = useReducedMotion();
+
+  // Last beat = "all done & pause". During earlier beats, beatIndex maps
+  // directly to the active step.
+  const allDone = beatIndex >= STEPS.length;
+  const activeStep = allDone ? -1 : beatIndex;
+
+  // Header duration ticker: 0 → 16 across the loop.
+  const elapsed = Math.min(16, allDone ? 16 : beatIndex * 2 + 1);
+
+  return (
+    <div
+      ref={ref}
+      className="flex flex-col h-full bg-white border border-mist-200 rounded-2xl overflow-hidden shadow-[0_18px_50px_-40px_rgba(15,23,42,0.35)] transition-shadow duration-200 hover:shadow-md"
+    >
+      <div className="p-1.5">
+        <div className="h-[320px] bg-mist-50 rounded-xl border border-mist-200/60 px-5 pt-6 pb-4 flex flex-col shrink-0">
+        {/* Header — status + counts + duration */}
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <motion.span
+              aria-hidden
+              className={`size-1.5 rounded-full ${
+                allDone ? "bg-emerald-500" : "bg-blue-500"
+              }`}
+              animate={
+                !allDone && !reduced
+                  ? { opacity: [1, 0.4, 1] }
+                  : { opacity: 1 }
+              }
+              transition={{
+                duration: 1.0,
+                repeat: Infinity,
+                ease: "easeInOut",
+              }}
+            />
+            <span
+              className={`text-[11px] font-medium capitalize ${
+                allDone ? "text-emerald-600" : "text-blue-600"
+              }`}
+            >
+              {allDone ? t("statusCompleted") : t("statusRunning")}
+            </span>
+            <span className="text-mist-300 text-[11px]">·</span>
+            <span className="text-[11px] text-mist-700 truncate">
+              <span className="font-semibold tabular-nums">47</span>{" "}
+              {t("translationsLabel")}
+            </span>
+          </div>
+          <span className="text-[11px] text-mist-400 font-mono tabular-nums shrink-0">
+            0:{elapsed.toString().padStart(2, "0")}
+          </span>
+        </div>
+
+        {/* Languages row */}
+        <div className="flex items-center gap-2 mb-4 flex-wrap">
+          {LANGUAGES.map((country) => (
+            <FlagIcon key={country} countryCode={country} className="w-4 h-3" />
+          ))}
+          <span className="text-[10px] text-mist-400 ml-1">→ CDN</span>
+        </div>
+
+        {/* Activity log — 7 sequential steps */}
+        <div className="bg-white rounded-xl border border-mist-200 shadow-sm px-4 py-3 overflow-hidden">
+          <div className="space-y-0">
+            {STEPS.map((step, i) => {
+              const isLast = i === STEPS.length - 1;
+              const status: "hidden" | "active" | "completed" =
+                allDone || i < activeStep
+                  ? "completed"
+                  : i === activeStep
+                    ? "active"
+                    : "hidden";
+              const isVisible = status !== "hidden";
+
+              return (
+                <motion.div
+                  key={step.key}
+                  animate={{
+                    opacity: isVisible ? 1 : 0.3,
+                    x: isVisible ? 0 : -4,
+                  }}
+                  transition={{ duration: DURATION.fast, ease: EASE_OUT }}
+                  className="flex items-stretch gap-3"
+                >
+                  <div className="flex flex-col items-center w-3 shrink-0">
+                    <motion.span
+                      aria-hidden
+                      className={`size-1.5 rounded-full mt-2 shrink-0 transition-colors duration-300 ${
+                        status === "completed"
+                          ? "bg-emerald-500"
+                          : status === "active"
+                            ? "bg-blue-500"
+                            : "bg-mist-300"
+                      }`}
+                      animate={
+                        status === "active" && !reduced
+                          ? { opacity: [1, 0.4, 1] }
+                          : { opacity: 1 }
+                      }
+                      transition={{
+                        duration: 1.0,
+                        repeat: Infinity,
+                        ease: "easeInOut",
+                      }}
+                    />
+                    {!isLast && (
+                      <div className="w-px flex-1 bg-mist-200 mt-1 relative overflow-hidden">
+                        <motion.div
+                          aria-hidden
+                          className="absolute inset-0 bg-emerald-400 origin-top"
+                          initial={false}
+                          animate={{
+                            scaleY: status === "completed" ? 1 : 0,
+                          }}
+                          transition={{
+                            duration: reduced ? 0 : 0.45,
+                            ease: EASE_OUT,
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                  <div
+                    className={`flex items-center justify-between flex-1 min-w-0 ${
+                      isLast ? "" : "pb-2.5"
+                    }`}
+                  >
+                    <p
+                      className={`text-[11px] leading-none truncate transition-colors duration-300 ${
+                        status === "completed"
+                          ? "text-mist-700"
+                          : status === "active"
+                            ? "text-mist-900 font-medium"
+                            : "text-mist-400"
+                      }`}
+                    >
+                      {t(step.key)}
+                    </p>
+                    <motion.span
+                      animate={{
+                        opacity: status === "completed" ? 1 : 0,
+                      }}
+                      transition={{ duration: DURATION.fast, ease: EASE_OUT }}
+                      className="text-[10px] text-mist-400 tabular-nums shrink-0 ml-3"
+                    >
+                      {step.time}
+                    </motion.span>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Result strip — fades in after Completed: live on CDN payoff */}
+        <motion.div
+          aria-hidden={!allDone}
+          initial={false}
+          animate={{
+            opacity: allDone ? 1 : 0,
+            y: allDone ? 0 : 6,
+          }}
+          transition={{
+            duration: DURATION.base,
+            ease: EASE_OUT,
+            delay: allDone ? 0.25 : 0,
+          }}
+          className="mt-3 flex items-center gap-2 px-3 py-2 rounded-lg bg-mist-100/70 border border-mist-200/70"
+        >
+          <span aria-hidden className="text-mist-500 shrink-0">
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              className="size-3.5"
+            >
+              <circle cx="8" cy="8" r="6.5" />
+              <path d="M1.5 8h13M8 1.5c2 2.4 2 10.6 0 13M8 1.5c-2 2.4-2 10.6 0 13" />
+            </svg>
+          </span>
+          <span className="text-[10px] font-mono text-mist-700 truncate">
+            cdn.better-i18n.com/acme/dashboard
+          </span>
+          <span className="text-[10px] text-mist-500 ml-auto whitespace-nowrap font-medium tabular-nums">
+            6 edges · 47ms
+          </span>
+        </motion.div>
+        </div>
+      </div>
+
+      <div className="px-6 pt-2 pb-5 flex-1 flex flex-col">
+        <h3 className="text-sm font-semibold text-mist-950">
+          {t("title")}
+        </h3>
+        <p className="mt-1.5 text-sm text-mist-600 leading-relaxed text-pretty">
+          {t("description")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/src/components/features/use-demo-loop.ts
+++ b/apps/landing/src/components/features/use-demo-loop.ts
@@ -1,0 +1,64 @@
+/**
+ * useDemoLoop — drives a multi-beat looping animation for feature cards.
+ *
+ * Runs ONLY while the target ref is in the viewport. When the user scrolls
+ * away the loop pauses, when they come back it resumes from beat 0. When
+ * `prefers-reduced-motion: reduce` is set, the hook freezes the demo at
+ * its final beat so the user sees the end state without any motion.
+ *
+ * This replaces the recursive setTimeout(runDemo) pattern in the legacy
+ * Features.tsx — that pattern ran forever and burned CPU/battery while
+ * off-screen.
+ */
+
+import { useEffect, useState, type RefObject } from "react";
+import { useInView, useReducedMotion } from "framer-motion";
+
+export type Beat = {
+  /** Milliseconds to hold this beat before advancing. */
+  durationMs: number;
+};
+
+type Options = {
+  /** Ordered list of beats. The last beat's duration acts as the loop pause. */
+  beats: ReadonlyArray<Beat>;
+  /** Element to observe. Loop runs while this element is in view. */
+  ref: RefObject<Element | null>;
+};
+
+export function useDemoLoop({ beats, ref }: Options) {
+  // Start the loop a little before the element fully enters the viewport.
+  const inView = useInView(ref, { margin: "-20% 0px 0px 0px" });
+  const reduced = useReducedMotion();
+  const [beatIndex, setBeatIndex] = useState(0);
+
+  useEffect(() => {
+    if (reduced) {
+      setBeatIndex(beats.length - 1);
+      return;
+    }
+
+    if (!inView) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const advance = (next: number) => {
+      if (cancelled) return;
+      setBeatIndex(next);
+      timer = setTimeout(
+        () => advance((next + 1) % beats.length),
+        beats[next].durationMs,
+      );
+    };
+
+    advance(0);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [inView, reduced, beats]);
+
+  return { beatIndex, inView, reduced };
+}

--- a/apps/landing/src/components/motion/MotionSection.tsx
+++ b/apps/landing/src/components/motion/MotionSection.tsx
@@ -1,0 +1,47 @@
+/**
+ * MotionSection — semantic <section> wrapper that animates on viewport entry.
+ *
+ * Wraps children in a single fade-up that runs once when the section
+ * enters the viewport. For internal stagger, compose with <Stagger>
+ * inside this component.
+ *
+ * Honors `prefers-reduced-motion` via framer-motion's `useReducedMotion`:
+ * when the user prefers reduced motion, children render at the visible
+ * state immediately with no animation.
+ */
+
+import { motion, useReducedMotion } from "framer-motion";
+import type { HTMLMotionProps } from "framer-motion";
+import type { ReactNode } from "react";
+
+import { fadeUp, VIEWPORT } from "@/lib/motion";
+
+type MotionSectionProps = Omit<
+  HTMLMotionProps<"section">,
+  "initial" | "whileInView" | "viewport" | "variants"
+> & {
+  children: ReactNode;
+  /** When true, skips entry animation entirely (useful for above-the-fold). */
+  immediate?: boolean;
+};
+
+export function MotionSection({
+  children,
+  immediate = false,
+  ...rest
+}: MotionSectionProps) {
+  const reduced = useReducedMotion();
+  const shouldAnimate = !reduced && !immediate;
+
+  return (
+    <motion.section
+      initial={shouldAnimate ? "hidden" : "visible"}
+      whileInView={shouldAnimate ? "visible" : undefined}
+      viewport={shouldAnimate ? VIEWPORT : undefined}
+      variants={shouldAnimate ? fadeUp : undefined}
+      {...rest}
+    >
+      {children}
+    </motion.section>
+  );
+}

--- a/apps/landing/src/components/motion/Stagger.tsx
+++ b/apps/landing/src/components/motion/Stagger.tsx
@@ -1,0 +1,64 @@
+/**
+ * Stagger — orchestrates sibling-by-sibling fade-up of its children.
+ *
+ * Usage:
+ *   <Stagger>
+ *     <StaggerItem>...</StaggerItem>
+ *     <StaggerItem>...</StaggerItem>
+ *   </Stagger>
+ *
+ * Each direct StaggerItem child enters with a `stagger`-second delay
+ * after its predecessor. Container is a single fade — children carry
+ * the per-item motion.
+ */
+
+import { motion, useReducedMotion } from "framer-motion";
+import type { HTMLMotionProps } from "framer-motion";
+import type { ReactNode } from "react";
+
+import { fadeUp, STAGGER, VIEWPORT, staggerContainer } from "@/lib/motion";
+
+type StaggerProps = Omit<
+  HTMLMotionProps<"div">,
+  "initial" | "whileInView" | "viewport" | "variants"
+> & {
+  children: ReactNode;
+  /** Seconds between each child's animation start. Default: 0.06s. */
+  stagger?: number;
+};
+
+export function Stagger({
+  children,
+  stagger = STAGGER.base,
+  ...rest
+}: StaggerProps) {
+  const reduced = useReducedMotion();
+  const shouldAnimate = !reduced;
+
+  return (
+    <motion.div
+      initial={shouldAnimate ? "hidden" : "visible"}
+      whileInView={shouldAnimate ? "visible" : undefined}
+      viewport={shouldAnimate ? VIEWPORT : undefined}
+      variants={shouldAnimate ? staggerContainer(stagger) : undefined}
+      {...rest}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+type StaggerItemProps = Omit<
+  HTMLMotionProps<"div">,
+  "variants"
+> & {
+  children: ReactNode;
+};
+
+export function StaggerItem({ children, ...rest }: StaggerItemProps) {
+  return (
+    <motion.div variants={fadeUp} {...rest}>
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/landing/src/lib/motion.ts
+++ b/apps/landing/src/lib/motion.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared motion grammar for the landing page.
+ *
+ * Single source of truth for easing curves, durations, stagger timings,
+ * and viewport defaults. All landing animations should pull from here —
+ * never hardcode magic numbers in components.
+ *
+ * UI-skills constraints honored:
+ * - Only `transform` + `opacity` are animated by consumers.
+ * - All entries use `ease-out` cubic.
+ * - Interaction feedback < 200ms.
+ * - `prefers-reduced-motion` is respected at the consumer level via
+ *   `useReducedMotion()` from framer-motion.
+ */
+
+import type { Variants } from "framer-motion";
+
+/** ease-out cubic — explicitly approved by user for Vercel/Clerk-style entrances. */
+export const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+
+/** Standard durations in seconds. Matches Tailwind's transition scale family. */
+export const DURATION = {
+  /** 200ms — interaction feedback ceiling per UI-skills. */
+  fast: 0.2,
+  /** 400ms — section/component entrances. */
+  base: 0.4,
+  /** 600ms — orchestrated reveals (rare). */
+  slow: 0.6,
+} as const;
+
+/** Stagger between sibling items in a Stagger group. */
+export const STAGGER = {
+  tight: 0.04,
+  base: 0.06,
+  loose: 0.1,
+} as const;
+
+/**
+ * Default viewport options for `whileInView`.
+ * - `once: true` — animate on first entry only; no re-trigger on re-scroll.
+ * - `margin: "-10% 0px"` — start animation slightly before the element fully enters.
+ */
+export const VIEWPORT = {
+  once: true,
+  margin: "-10% 0px",
+} as const;
+
+/** Standard fade-up entrance (used by sections and most cards). */
+export const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 16 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: DURATION.base, ease: EASE_OUT },
+  },
+};
+
+/** Subtle fade-only — used when motion should be felt but not seen. */
+export const fade: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { duration: DURATION.base, ease: EASE_OUT },
+  },
+};
+
+/** Word-level reveal for hero displays (used with split text). */
+export const displayWord: Variants = {
+  hidden: { opacity: 0, y: 12, filter: "blur(8px)" },
+  visible: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: DURATION.slow, ease: EASE_OUT },
+  },
+};
+
+/** Container variants that drive children stagger. */
+export function staggerContainer(stagger: number = STAGGER.base): Variants {
+  return {
+    hidden: {},
+    visible: {
+      transition: { staggerChildren: stagger },
+    },
+  };
+}

--- a/apps/landing/src/routes/$locale/pricing.tsx
+++ b/apps/landing/src/routes/$locale/pricing.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { SpriteIcon } from "@/components/SpriteIcon";
 import { MarketingLayout } from "@/components/MarketingLayout";
 import Pricing from "@/components/Pricing";
 import { getPageHead, getFAQSchema, formatStructuredData } from "@/lib/page-seo";
@@ -61,15 +60,6 @@ function PricingPage() {
   const { locale } = Route.useParams();
   const { plans } = Route.useLoaderData();
 
-  const trustBadges = [
-    { key: "uptime", label: t("trust.uptime") },
-    { key: "gdpr", label: t("trust.gdpr") },
-    { key: "soc2", label: t("trust.soc2") },
-    { key: "support", label: t("trust.support") },
-    { key: "cdn", label: t("trust.cdn") },
-    { key: "encryption", label: t("trust.encryption") },
-  ];
-
   return (
     <MarketingLayout showCTA={false}>
       {/* Pricing Section — use h1 on dedicated pricing page */}
@@ -79,7 +69,7 @@ function PricingPage() {
       <PricingComparison />
 
       {/* FAQ Section */}
-      <section className="py-16 bg-white">
+      <section className="py-16">
         <div className="mx-auto max-w-3xl px-6 lg:px-10">
           <h2 className="font-display text-2xl font-medium text-mist-950 mb-8 text-center">
             {t("faq.title")}
@@ -105,25 +95,6 @@ function PricingPage() {
               question={t("faq.discounts.question")}
               answer={t("faq.discounts.answer")}
             />
-          </div>
-        </div>
-      </section>
-
-      {/* Trust Section */}
-      <section className="py-16 bg-mist-100">
-        <div className="mx-auto max-w-7xl px-6 lg:px-10">
-          <div className="text-center mb-12">
-            <h2 className="font-display text-2xl font-medium text-mist-950">
-              {t("trust.title")}
-            </h2>
-          </div>
-          <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-6">
-            {trustBadges.map((item) => (
-              <div key={item.key} className="flex items-center gap-2 justify-center p-4 rounded-lg bg-white border border-mist-200">
-                <SpriteIcon name="checkmark" className="size-4 text-mist-950" />
-                <span className="text-sm font-medium text-mist-700">{item.label}</span>
-              </div>
-            ))}
           </div>
         </div>
       </section>

--- a/apps/landing/src/routes/__root.tsx
+++ b/apps/landing/src/routes/__root.tsx
@@ -27,6 +27,7 @@ import { SvgSprite } from "../components/SvgSprite";
 import { CookieBanner } from "../components/CookieBanner";
 import { WebMcpRegistrar } from "../components/WebMcpRegistrar";
 import { IconArrowLeft } from "@central-icons-react/round-outlined-radius-2-stroke-2";
+import { HelpwayWidget } from "@helpway/react";
 
 /**
  * Per-request SSR side-channel for i18n messages.
@@ -294,18 +295,6 @@ function NotFoundPage() {
   );
 }
 
-function BetterSupportWidget() {
-  useEffect(() => {
-    if (document.getElementById("better-support-widget")) return;
-    const s = document.createElement("script");
-    s.id = "better-support-widget";
-    s.src = "https://api.helpway.ai/widget.js";
-    s.setAttribute("data-key", "pk_live_Nir-sHLl1_qc9S9EuV9RdNN5");
-    s.defer = true;
-    document.body.appendChild(s);
-  }, []);
-  return null;
-}
 
 function RootComponent() {
   const { locale, locales, requestId } = Route.useRouteContext();
@@ -404,7 +393,7 @@ function RootComponent() {
           </BetterI18nProvider>
         </QueryClientProvider>
         <Scripts />
-        <BetterSupportWidget />
+        <HelpwayWidget apiKey="pk_live_Nir-sHLl1_qc9S9EuV9RdNN5" locale={locale} />
       </body>
     </html>
   );

--- a/apps/landing/src/routes/__root.tsx
+++ b/apps/landing/src/routes/__root.tsx
@@ -27,7 +27,11 @@ import { SvgSprite } from "../components/SvgSprite";
 import { CookieBanner } from "../components/CookieBanner";
 import { WebMcpRegistrar } from "../components/WebMcpRegistrar";
 import { IconArrowLeft } from "@central-icons-react/round-outlined-radius-2-stroke-2";
-import { HelpwayWidget } from "@helpway/react";
+import { lazy, Suspense } from "react";
+
+const LazyHelpwayWidget = lazy(() =>
+  import("@helpway/react").then((m) => ({ default: m.HelpwayWidget })),
+);
 
 /**
  * Per-request SSR side-channel for i18n messages.
@@ -393,7 +397,11 @@ function RootComponent() {
           </BetterI18nProvider>
         </QueryClientProvider>
         <Scripts />
-        <HelpwayWidget apiKey="pk_live_Nir-sHLl1_qc9S9EuV9RdNN5" locale={locale} />
+        {typeof document !== "undefined" && (
+          <Suspense fallback={null}>
+            <LazyHelpwayWidget apiKey="pk_live_Nir-sHLl1_qc9S9EuV9RdNN5" locale={locale} />
+          </Suspense>
+        )}
       </body>
     </html>
   );

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -46,8 +46,6 @@ export default defineConfig(async ({ mode }) => {
       rollupOptions: {
         output: {
           manualChunks(id: string) {
-            // Demo is lazy-loaded — keep it in its own chunk
-            if (id.includes("/demo/")) return "demo";
             // Split heavy vendor libs so the main chunk stays lean.
             // These vendor chunks are immutable-cached and shared across pages.
             if (id.includes("node_modules/@central-icons-react")) return "vendor-icons";

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -42,6 +42,21 @@ export default defineConfig(async ({ mode }) => {
   }
 
   return {
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id: string) {
+            // Demo is lazy-loaded — keep it in its own chunk
+            if (id.includes("/demo/")) return "demo";
+            // Split heavy vendor libs so the main chunk stays lean.
+            // These vendor chunks are immutable-cached and shared across pages.
+            if (id.includes("node_modules/@central-icons-react")) return "vendor-icons";
+            if (id.includes("node_modules/lucide-react")) return "vendor-icons";
+            if (id.includes("node_modules/html-react-parser") || id.includes("node_modules/html-dom-parser")) return "vendor-html-parser";
+          },
+        },
+      },
+    },
     define: {
       "import.meta.env.BETTER_I18N_CONTENT_API_KEY": JSON.stringify(
         env.BETTER_I18N_CONTENT_API_KEY,

--- a/bun.lock
+++ b/bun.lock
@@ -153,6 +153,7 @@
         "@better-i18n/ui": "^0.2.0",
         "@better-i18n/use-intl": "workspace:*",
         "@central-icons-react/round-outlined-radius-2-stroke-2": "^1.1.90",
+        "@helpway/react": "^0.3.2",
         "@radix-ui/react-hover-card": "^1.1.15",
         "@remotion/player": "^4.0.450",
         "@tailwindcss/vite": "^4.1.18",
@@ -1038,6 +1039,8 @@
     "@graphql-tools/utils": ["@graphql-tools/utils@10.11.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
+
+    "@helpway/react": ["@helpway/react@0.3.2", "", { "dependencies": { "@trpc/client": "^11.5.1", "zustand": "^5.0.11" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-oFPjMBkSxKaGJZn5I1/UNW71knshleTmCpbmh1gQjW2li9WzFfnScJ9z+ibq9T46ERJV7KxYG6Y9tu9FH5ajWQ=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 
@@ -4681,6 +4684,8 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
+    "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@alcalzone/ansi-tokenize/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
@@ -5132,6 +5137,8 @@
     "decompress-response/mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
     "docs/next": ["next@16.1.1", "", { "dependencies": { "@next/env": "16.1.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.1", "@next/swc-darwin-x64": "16.1.1", "@next/swc-linux-arm64-gnu": "16.1.1", "@next/swc-linux-arm64-musl": "16.1.1", "@next/swc-linux-x64-gnu": "16.1.1", "@next/swc-linux-x64-musl": "16.1.1", "@next/swc-win32-arm64-msvc": "16.1.1", "@next/swc-win32-x64-msvc": "16.1.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w=="],
+
+    "docs/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "dot-prop/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -153,7 +153,7 @@
         "@better-i18n/ui": "^0.2.0",
         "@better-i18n/use-intl": "workspace:*",
         "@central-icons-react/round-outlined-radius-2-stroke-2": "^1.1.90",
-        "@helpway/react": "0.3.2",
+        "@helpway/react": "0.3.4",
         "@radix-ui/react-hover-card": "^1.1.15",
         "@remotion/player": "^4.0.450",
         "@tailwindcss/vite": "^4.1.18",
@@ -1040,7 +1040,7 @@
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
-    "@helpway/react": ["@helpway/react@0.3.2", "", { "dependencies": { "@trpc/client": "^11.5.1", "zustand": "^5.0.11" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-oFPjMBkSxKaGJZn5I1/UNW71knshleTmCpbmh1gQjW2li9WzFfnScJ9z+ibq9T46ERJV7KxYG6Y9tu9FH5ajWQ=="],
+    "@helpway/react": ["@helpway/react@0.3.4", "", { "dependencies": { "@trpc/client": "^11.5.1", "zustand": "^5.0.11" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-kYV2yHCW/1ygG2rbbo0Sr3fw11F8+tfgQmBKiRl9becQV4h/jPQryDF0LLeRTr8s/k6OwZoj0mKnZ/e/fEjxog=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -153,7 +153,7 @@
         "@better-i18n/ui": "^0.2.0",
         "@better-i18n/use-intl": "workspace:*",
         "@central-icons-react/round-outlined-radius-2-stroke-2": "^1.1.90",
-        "@helpway/react": "^0.3.2",
+        "@helpway/react": "0.3.2",
         "@radix-ui/react-hover-card": "^1.1.15",
         "@remotion/player": "^4.0.450",
         "@tailwindcss/vite": "^4.1.18",

--- a/packages/core/src/react/locale-dropdown-base.tsx
+++ b/packages/core/src/react/locale-dropdown-base.tsx
@@ -484,15 +484,26 @@ export function LocaleDropdownBase({
     };
   }, []);
 
-  // Use top/left instead of floatingStyles (which uses transform: translate).
-  // Our CSS animations also use transform — they'd override the positioning.
-  const { refs, x, y, placement: resolvedPlacement } = useFloating({
-    open: true,
-    strategy: "absolute",
-    placement: placementProp === "top" ? "top-end" : "bottom-end",
-    middleware: [offset(4), flip({ padding: 16 }), shift({ padding: 8 })],
-    whileElementsMounted: autoUpdate,
-  });
+  // SSR guard: @floating-ui/react calls useId() internally which fails
+  // during Vite SSR dev (React context not fully initialized). On the server
+  // we skip floating positioning — the dropdown is always closed on first
+  // render anyway, so coordinates don't matter.
+  const isServer = typeof window === "undefined";
+  const clientFloating = isServer
+    ? null
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    : useFloating({
+        open: true,
+        strategy: "absolute",
+        placement: placementProp === "top" ? "top-end" : "bottom-end",
+        middleware: [offset(4), flip({ padding: 16 }), shift({ padding: 8 })],
+        whileElementsMounted: autoUpdate,
+      });
+  const noopRef = useRef(null);
+  const refs = clientFloating?.refs ?? { setReference: () => {}, setFloating: () => {}, floating: noopRef, reference: noopRef };
+  const x = clientFloating?.x ?? 0;
+  const y = clientFloating?.y ?? 0;
+  const resolvedPlacement = clientFloating?.placement ?? (placementProp === "top" ? "top-end" : "bottom-end");
 
   const menuPositionStyle: CSSProperties = {
     position: "absolute",


### PR DESCRIPTION
## Summary
- **Perf:** lazy-load Demo + MobileNav, split vendor chunks for LCP, prerender passthrough + Vite SSG config
- **Helpway:** replace widget.js script injection with @helpway/react (client-only, lazy), bump to 0.3.2
- **Core SSR fix:** guard useFloating SSR call in LocaleDropdownBase
- **Landing UI/i18n polish:** refine Pricing (subtitle + tighter padding), PricingComparison (max-w-7xl, left-aligned, "Better I18N" wordmark, wider cells), UserSegments (segment card chrome parity, min-h slots, trailing-slash route fix); drop bg-white on FAQ; remove redundant trust badges (footer covers them)
- **Motion refactor:** extract AI/MCP/Publish feature cards, add reusable MotionSection + Stagger primitives + lib/motion.ts shared timing tokens

## i18n updates (already published to CDN)
- `pricing.comparison.title`, `pricing.comparison.subtitle` — refreshed source + 22 target languages
- `pricing.subtitle` — new key + 22 target languages
- `segments.developers.description` — extended source + 22 target languages

## Test plan
- [ ] Run `bun run build` locally — SSG output passes
- [ ] LCP metric on mobile homepage improves vs baseline
- [ ] All segment cards render same height (Translators / Developers / ProductTeams)
- [ ] PricingComparison spans full container width on lg+
- [ ] FAQ section reads against gradient bg (no white block)
- [ ] Cloudflare deploy fires on merge → verify production renders new copy