### PR TITLE
fix(use-intl): suppress useRouter warning in non-TanStack Router apps

### DIFF
--- a/.changeset/fix-router-warning.md
+++ b/.changeset/fix-router-warning.md
@@ -1,0 +1,5 @@
+---
+"@better-i18n/use-intl": patch
+---
+
+Suppress "useRouter must be used inside RouterProvider" console warning in non-TanStack Router apps (e.g. react-router-dom). Pass `{ warn: false }` to TanStack Router's `useRouter()` — the try/catch fallback already handles missing context gracefully.

--- a/packages/use-intl/src/hooks/useLocaleRouter.ts
+++ b/packages/use-intl/src/hooks/useLocaleRouter.ts
@@ -110,14 +110,14 @@ export function useLocaleRouter(): UseLocaleRouterReturn {
   let location: ReturnType<typeof useLocation> | null = null;
 
   try {
-     
-    router = useRouter();
+    // warn: false suppresses the "must be used inside <RouterProvider>" console.warn
+    // from tiny-warning when no TanStack Router context exists (e.g. react-router-dom apps).
+    router = useRouter({ warn: false });
   } catch {
     // No TanStack Router context — will use context-based navigation
   }
 
   try {
-     
     location = useLocation();
   } catch {
     // No TanStack Router context


### PR DESCRIPTION
## Summary
- Pass `{ warn: false }` to TanStack Router's `useRouter()` in `useLocaleRouter` hook
- Prevents `console.warn("useRouter must be used inside a <RouterProvider>")` noise in apps using `react-router-dom` or plain Vite (no TanStack Router)
- The existing `try/catch` fallback already handles missing context gracefully — this just silences the warning

## Context
CarnaTest exam app (`apps/exam`) uses `react-router-dom` with `<BrowserRouter>`, not TanStack Router. The `useLocaleRouter` hook correctly falls back to context-based locale switching, but the warning floods the console in development.

## Test plan
- [ ] Verify no console warning in CarnaTest exam app (react-router-dom)
- [ ] Verify locale switching still works in TanStack Router apps (cfs-app, cft web)
- [ ] Verify locale switching still works in non-router apps (plain Vite)