### PR TITLE
fix(landing): eliminate meta title race condition

### DIFF
--- a/apps/landing/src/lib/ssr-messages.ts
+++ b/apps/landing/src/lib/ssr-messages.ts
@@ -1,0 +1,22 @@
+import type { Messages } from "@better-i18n/use-intl";
+
+const store = new Map<string, Messages>();
+const MAX_SIZE = 50;
+
+export function storeMessages(requestId: string, messages: Messages): void {
+  if (store.size >= MAX_SIZE) {
+    const first = store.keys().next().value;
+    if (first) store.delete(first);
+  }
+  store.set(requestId, messages);
+}
+
+export function readMessages(requestId: string): Messages | undefined {
+  return store.get(requestId);
+}
+
+export function consumeMessages(requestId: string): Messages | undefined {
+  const msgs = store.get(requestId);
+  if (msgs) store.delete(requestId);
+  return msgs;
+}

--- a/apps/landing/src/routes/$locale/index.tsx
+++ b/apps/landing/src/routes/$locale/index.tsx
@@ -45,6 +45,7 @@ import {
 import { getHomePageStructuredData, getFAQSchema, formatStructuredData } from "@/lib/structured-data";
 import { getChangelogsMeta } from "@/lib/changelog";
 import { withTimeout } from "@/lib/fetch-utils";
+import { readMessages } from "@/lib/ssr-messages";
 import { getMessages } from "@better-i18n/use-intl/server";
 import { i18nConfig } from "@/i18n.config";
 import { getPricingPlans, type PricingPlan } from "@/lib/content";
@@ -69,11 +70,13 @@ type HomeLoaderData = {
 export const Route = createFileRoute("/$locale/")({
   loader: async ({ context, params }): Promise<HomeLoaderData> => {
     const locale = params.locale as string;
-    // Use metadata-only fetch (single API call) instead of full content (N+1 calls)
-    // to keep homepage load time within crawler timeout limits.
-    // Wrap with 3s timeout so the page renders even if the API is slow.
-    const [allMessages, releases, plans] = await Promise.all([
-      getMessages({ project: i18nConfig.project, locale: context.locale }),
+    // Messages come from root's beforeLoad (sequential, guaranteed populated).
+    // readMessages returns the same data root loaded — no separate CDN call.
+    const allMessages = readMessages(context.requestId) ?? await getMessages({
+      project: i18nConfig.project,
+      locale: context.locale,
+    });
+    const [releases, plans] = await Promise.all([
       withTimeout(getChangelogsMeta(locale), 3000, []),
       getPricingPlans(context.locale),
     ]);

--- a/apps/landing/src/routes/__root.tsx
+++ b/apps/landing/src/routes/__root.tsx
@@ -20,6 +20,7 @@ import { detectLocale } from "@better-i18n/core";
 import { getRequestHeader } from "@tanstack/react-start/server";
 import { i18nConfig } from "../i18n.config";
 import { filterMessagesByPath, getCdnNamespacesForPage, extractPagePath } from "../lib/page-namespaces";
+import { storeMessages, readMessages } from "../lib/ssr-messages";
 import { fetchLocales } from "../lib/locales";
 import appCss from "../styles.css?url";
 import { MarketingLayout } from "../components/MarketingLayout";
@@ -182,14 +183,8 @@ export const Route = createRootRouteWithContext<RouterContext>()({
     const locale = getLocaleFromPath(location.pathname, localeConfig);
     const requestId = crypto.randomUUID();
 
-    return { locale, locales, requestId };
-  },
-
-  loader: async ({ context, location }) => {
-    // Selective namespace loading: only fetch CDN namespace files this page needs
-    // instead of all 103 namespaces (103 fetches → ~10 fetches).
-    // getCdnNamespacesForPage resolves dot-path specs (e.g., "marketing.compare.crowdin")
-    // to CDN file names ("marketing"), since CDN has one file per top-level namespace.
+    // Load messages ONCE here (beforeLoad runs sequentially parent→child).
+    // Child loaders read from the shared Map via requestId — zero race condition.
     const pagePath = extractPagePath(location.pathname);
     const cdnNamespaces = getCdnNamespacesForPage(pagePath) ?? undefined;
 
@@ -199,8 +194,19 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
     const allMessages = await getMessages({
       project: i18nConfig.project,
-      locale: context.locale,
+      locale,
       namespaces: cdnNamespaces,
+    });
+    storeMessages(requestId, allMessages);
+
+    return { locale, locales, requestId };
+  },
+
+  loader: async ({ context, location }) => {
+    const allMessages = readMessages(context.requestId) ?? await getMessages({
+      project: i18nConfig.project,
+      locale: context.locale,
+      namespaces: getCdnNamespacesForPage(extractPagePath(location.pathname)) ?? undefined,
     });
     const messages = filterMessagesByPath(allMessages, location.pathname);
 


### PR DESCRIPTION
## Summary
- Move `getMessages()` from root `loader` to `beforeLoad` — beforeLoad runs sequentially (parent→child), loaders run in parallel
- Child route reads from shared per-request Map instead of making independent CDN call
- Eliminates intermittent SSR failure where `<title>` was "Better I18N" instead of full localized title

## Root Cause
TanStack Router runs `beforeLoad` sequentially but `loader` functions in **parallel**. Both root and child called `getMessages()` independently — child's CDN fetch intermittently failed during SSR, producing `headData` with truncated title. The dehydrated payload carried the wrong meta to the client.

## Test plan
- [ ] Verify `<title>` tag in SSR HTML via `curl -sL https://better-i18n.com/en/ | grep '<title>'`
- [ ] Verify `document.title` in browser after full hydration matches SSR
- [ ] Check other pages (pricing, features) still have correct meta