### PR TITLE
docs(content): fix stale field-type lists + document repeatable-content rule

### DIFF
--- a/apps/docs/content/core/webhooks.mdx
+++ b/apps/docs/content/core/webhooks.mdx
@@ -621,7 +621,7 @@ Fired when a custom field is added to, modified on, or removed from a content mo
     "model": "blog-post",
     "field": {
       "name": "hero_image",
-      "type": "image",
+      "type": "media",
       "localized": false
     },
     "actor": { "userId": "usr_xyz", "via": "ui" }

--- a/apps/docs/content/mcp/tool-reference.mdx
+++ b/apps/docs/content/mcp/tool-reference.mdx
@@ -401,6 +401,8 @@ Add a custom field to a content model. Field name must be snake_case.
 - `fieldConfig` (optional): Type-specific configuration
   - `targetModel`: Target model slug for relation fields
 
+There is no array or group field type. To model repeating content, do **not** create numbered fields (`feature_1`, `feature_2`, `tag_1_slug`…) — that is an anti-pattern. Use a body **block** (code-first, registered per project, backed by a JSON Schema that supports arrays/nested objects, inserted via the `/` slash picker) for page-composition repetition, or a `relation` field for references to other entries.
+
 </AccordionItem>
 
 <AccordionItem title="updateField">

--- a/apps/docs/content/sdk/api-reference.mdx
+++ b/apps/docs/content/sdk/api-reference.mdx
@@ -412,7 +412,7 @@ Field definition returned inside `ContentModel.fields`.
 | --- | --- | --- |
 | `name` | `string` | Field identifier (snake_case) |
 | `displayName` | `string` | Human-readable field label |
-| `type` | `string` | Field type (`text`, `textarea`, `richtext`, `number`, `boolean`, `date`, `datetime`, `enum`, `media`, `relation`, `user_select`) |
+| `type` | `string` | Field type (`text`, `textarea`, `richtext`, `number`, `boolean`, `date`, `datetime`, `enum`, `media`, `relation`) |
 | `required` | `boolean` | Whether the field is required |
 | `localized` | `boolean` | Whether the field is translated per language |
 | `enumValues` | `ContentModelEnumValue[] \| undefined` | Enum options — only present when `type` is `"enum"` |

--- a/apps/docs/content/sdk/models.mdx
+++ b/apps/docs/content/sdk/models.mdx
@@ -21,13 +21,25 @@ Better i18n's headless CMS organizes content into **models** and **entries**. Mo
 | Type | Use for | Localized? |
 |---|---|---|
 | `text` | Short strings — titles, names | Yes |
+| `textarea` | Multi-line plain text | Yes |
 | `richtext` | Long-form content with formatting | Yes |
 | `number` | Counts, prices, ratings | No (usually) |
 | `boolean` | Toggle flags — featured, archived | No |
-| `date` | Publish date, event start | No |
-| `image` | Media reference | No |
-| `reference` | Link to another entry | No |
-| `json` | Free-form structured data | Optional |
+| `date` | Date only — publish date, event start | No |
+| `datetime` | Date + time | No |
+| `enum` | A fixed set of options | No |
+| `media` | Image / file reference | No |
+| `relation` | Link to another entry (see [Relations](#relations)) | No |
+
+There is **no array or group field type**, and `relation` points to a single entry. To model "more than one of something", see below — do not reach for numbered fields.
+
+## Modeling repeating content
+
+When you need more than one of something, pick the right home for it instead of inventing extra fields:
+
+1. **Page-composition / repeating structured content → body blocks.** Hero sections, feature grids, FAQ lists, CTAs, and any repeating section belong in the entry **body**, not as sidebar fields. Blocks are code-first: you register them per project with a `defineBlock()`-style declaration backed by a JSON Schema — which **does** support arrays and nested objects — and editors insert them via the `/` slash picker.
+2. **References to other entries → a `relation` field.** A post pointing to its category, author, or tags is a relation; resolve it with `.expand()` (see [Relations](#relations)).
+3. **Never model repetition as numbered sidebar fields.** `Feature 1`, `Feature 2`, `Tag 1 Slug`… is an anti-pattern — it produces an unusable wall of fields and cannot scale. Use a body block (case 1) or a relation (case 2).
 
 ## Localized vs. universal fields
 


### PR DESCRIPTION
## Why
The content-CMS field-type lists diverged from the real `contentModelFieldTypeEnum`, and the docs **never explained how to model repeating content** — so users reached for numbered fields (`Feature 1`, `Tag 1 Slug`…), an unusable anti-pattern seen live in our own CMS.

## What
- **`sdk/models`** — corrected the Field types table to match the enum (`text·textarea·richtext·number·boolean·date·datetime·enum·media·relation`; was `image`/`reference`/`json`, missing `textarea`/`datetime`/`enum`) and added a **"Modeling repeating content"** section: blocks for page-composition repetition, `relation` for entry references, never numbered fields.
- **`mcp/tool-reference`** — added repeatable-content guidance to `addField`.
- **`sdk/api-reference`** — dropped stale `user_select` from the field-type list.
- **`core/webhooks`** — fixed example field type `image` → `media`.

Verified against current `main`; every type list now matches `platform/packages/schemas/src/content.ts` (no stale type names remain). Docs track (E) of the repeatable-content plan; ships independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)