### PR TITLE
feat(mcp-content): support fieldConfig.multiple for multi-valued relations

### DIFF
--- a/packages/mcp-content/src/tools/addField.ts
+++ b/packages/mcp-content/src/tools/addField.ts
@@ -42,6 +42,7 @@ const inputSchema = projectSchema.extend({
   options: fieldOptionsSchema,
   fieldConfig: z.object({
     targetModel: z.string().optional(),
+    multiple: z.boolean().optional().describe("If true, the relation holds an ordered array of target entries instead of one"),
   }).optional(),
 });
 
@@ -127,6 +128,7 @@ EXAMPLES:
           description: "Type-specific configuration (e.g., targetModel for relation fields)",
           properties: {
             targetModel: { type: "string", description: "Target model slug for relation fields" },
+            multiple: { type: "boolean", description: "If true, the relation holds an ordered array of target entries instead of one" },
           },
         },
       },

--- a/packages/mcp-content/src/tools/createContentModel.ts
+++ b/packages/mcp-content/src/tools/createContentModel.ts
@@ -41,6 +41,7 @@ const fieldDefinition = z.object({
   options: fieldOptionsSchema,
   fieldConfig: z.object({
     targetModel: z.string().optional(),
+    multiple: z.boolean().optional().describe("If true, the relation holds an ordered array of target entries instead of one"),
   }).optional(),
 });
 
@@ -161,6 +162,7 @@ EXAMPLES:
                 description: "Type-specific configuration (e.g., targetModel for relation fields)",
                 properties: {
                   targetModel: { type: "string", description: "Target model slug for relation fields" },
+                  multiple: { type: "boolean", description: "If true, the relation holds an ordered array of target entries instead of one" },
                 },
               },
             },

--- a/packages/mcp-content/src/tools/updateField.ts
+++ b/packages/mcp-content/src/tools/updateField.ts
@@ -41,6 +41,7 @@ const inputSchema = projectSchema.extend({
   options: fieldOptionsSchema,
   fieldConfig: z.object({
     targetModel: z.string().optional(),
+    multiple: z.boolean().optional().describe("If true, the relation holds an ordered array of target entries instead of one"),
   }).optional(),
 });
 
@@ -119,6 +120,7 @@ EXAMPLES:
           description: "Type-specific configuration (e.g., targetModel for relation fields)",
           properties: {
             targetModel: { type: "string", description: "Target model slug for relation fields" },
+            multiple: { type: "boolean", description: "If true, the relation holds an ordered array of target entries instead of one" },
           },
         },
       },

--- a/packages/mcp-types/src/content-compact-types.ts
+++ b/packages/mcp-types/src/content-compact-types.ts
@@ -50,8 +50,8 @@ export interface CompactContentModelField {
   pos: number;
   /** Field options (e.g., { ev: [{ l: "Published", v: "published" }] } for enum values, sit = showInTable) */
   opts?: { ev?: Array<{ l: string; v: string }>; sit?: boolean } | null;
-  /** Type-specific config (e.g., { tm: "categories" } for relation → targetModel) */
-  fc?: { tm?: string } | null;
+  /** Type-specific config (e.g., { tm: "categories" } for relation → targetModel; mp = multiple) */
+  fc?: { tm?: string; mp?: boolean } | null;
 }
 
 /**

--- a/packages/mcp-types/src/content-schemas.ts
+++ b/packages/mcp-types/src/content-schemas.ts
@@ -404,6 +404,7 @@ const mcpFieldOptionsSchema = z.object({
 /** Type-specific field configuration (e.g., targetModel for relation fields) */
 const mcpFieldConfigSchema = z.object({
   targetModel: z.string().optional().describe("Target content model slug for relation fields"),
+  multiple: z.boolean().optional().describe("If true, the relation holds an ordered array of target entries instead of one"),
 }).optional();
 
 /** Field definition for creating content models */

--- a/packages/mcp-types/src/content-types.ts
+++ b/packages/mcp-types/src/content-types.ts
@@ -16,6 +16,8 @@
 export interface ContentModelFieldConfig {
   /** Target content model slug for relation fields */
   targetModel?: string;
+  /** If true, the relation holds an ordered array of target entries instead of one */
+  multiple?: boolean;
 }
 
 /** Single enum option */


### PR DESCRIPTION
## Why
Multi-valued relations cannot be set via MCP. `addField`/`updateField`/`createContentModel` each define their **own inline** `fieldConfig` zod schema (only `targetModel`), so `multiple` is stripped before the request is forwarded to the platform tRPC API — even though the platform API already accepts `fieldConfig.multiple`.

Discovered while migrating the masraff CMS blog taxonomy to a multi-relation: the MCP `addField` call silently created a **single** relation (`fc: { tm: "blog-categories" }`, no `multiple`).

> Note: `platform/packages/mcp-types` had `multiple` added separately, but the MCP **server** consumes **`oss/packages/mcp-types`** — a parallel copy that never got the change. This PR fixes the copy the server actually uses.

## What
- **addField / updateField / createContentModel** — accept `multiple` in the inline zod `fieldConfig` schema **and** advertise it in the tool JSON-Schema. Forwarding unchanged (`input.fieldConfig` already passes through; the tRPC client is typed `<any>`).
- **mcp-types** — `multiple?: boolean` on `ContentModelFieldConfig`, on `mcpFieldConfigSchema`, and `mp` on the compact field type (`fc`).

## Verification
- Typecheck (`tsc --noEmit`): **no new errors** (6 pre-existing errors live in unrelated block tools; confirmed identical on a clean baseline).
- Tests: addField / updateField / createContentModel suites green (**37 tests**).
- Built via a 4-agent fan-out (one per tool + shared types) against a frozen contract, then a typecheck/test/diff verify pass.

After release, the masraff blog taxonomy migration (multi-relation) can proceed via MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)